### PR TITLE
semgrep: Find current issues first and baseline second

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -60,9 +60,9 @@ def main(
     publish_token: str,
     publish_deployment: int,
 ) -> NoReturn:
-    click.echo("=== setting up environment")
+    click.echo("=== detecting environment")
     click.echo(
-        f"| versions: "
+        f"| versions     - "
         f"semgrep {sh.semgrep(version=True).strip()} on "
         f"{sh.python(version=True).strip()}"
     )
@@ -84,15 +84,17 @@ def main(
         ),
     )
     click.echo(
-        f"| environment: "
+        f"| environment  - "
         f"running in {obj.meta.environment}, "
         f"triggering event is '{obj.meta.event_name}'"
     )
 
     if obj.sapp.is_configured:
-        click.echo(f"| semgrep.live: logged in as deployment #{obj.sapp.deployment_id}")
+        click.echo(
+            f"| semgrep.live - logged in as deployment #{obj.sapp.deployment_id}"
+        )
     else:
-        click.echo("| semgrep.live: not logged in")
+        click.echo("| semgrep.live - not logged in")
 
     maybe_print_debug_info(obj.meta)
 

--- a/src/semgrep_agent/meta.py
+++ b/src/semgrep_agent/meta.py
@@ -2,6 +2,7 @@ import json
 import os
 import urllib.parse
 from dataclasses import dataclass
+from dataclasses import field
 from pathlib import Path
 from typing import Any
 from typing import Dict
@@ -27,7 +28,7 @@ class GitMeta:
 
     ctx: click.Context
     cli_baseline_ref: Optional[str] = None
-    environment: str = "git"
+    environment: str = field(default="git", init=False)
 
     @cachedproperty
     def event_name(self) -> str:
@@ -88,7 +89,7 @@ class GitMeta:
 class GithubMeta(GitMeta):
     """Gather metadata from GitHub Actions."""
 
-    environment = "github-actions"
+    environment: str = field(default="github-actions", init=False)
 
     def glom_event(self, spec: TType) -> Any:
         return glom(self.event, spec, default=None)
@@ -166,7 +167,7 @@ class GithubMeta(GitMeta):
 class GitlabMeta(GitMeta):
     """Gather metadata from GitLab 10.0+"""
 
-    environment = "gitlab-ci"
+    environment: str = field(default="gitlab-ci", init=False)
 
     @staticmethod
     def _get_remote_url() -> str:

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -132,10 +132,13 @@ def invoke_semgrep(ctx: click.Context) -> FindingSets:
     else:
         with targets.baseline_paths() as paths, get_semgrep_config(ctx) as config_args:
             if paths:
+                paths_with_findings = {finding.path for finding in findings.current}
+                paths_to_check = set(str(path) for path in paths) & paths_with_findings
                 click.echo(
-                    "=== looking for pre-existing issues in " + unit_len(paths, "file")
+                    "=== looking for pre-existing issues in "
+                    + unit_len(paths_to_check, "file")
                 )
-                for chunk in chunked_iter(paths, PATHS_CHUNK_SIZE):
+                for chunk in chunked_iter(paths_to_check, PATHS_CHUNK_SIZE):
                     args = ["--json", *config_args]
                     for path in chunk:
                         args.extend(["--include", path])


### PR DESCRIPTION
This lets us skip the baseline scan if there are no current issues which
could be considered new anyway.

This is the output when filtering to paths with current issues:
 
```
=== setting up agent configuration
| using semgrep rules from r/all
| using default path ignore rules of common test and dependency directories
| looking at 122 changed files
| skipping 46 files based on path ignore rules
=== looking for current issues in 76 files
| 13 current issues found
=== looking for pre-existing issues in 5 files
| 8 pre-existing issues found
...
```