### PR TITLE
Use file targeting instead of include when invoking semgrep

### DIFF
--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -133,9 +133,9 @@ def invoke_semgrep(ctx: click.Context) -> FindingSets:
     with targets.current_paths() as paths, get_semgrep_config(ctx) as config_args:
         click.echo("=== looking for current issues in " + unit_len(paths, "file"))
         for chunk in chunked_iter(paths, PATHS_CHUNK_SIZE):
-            args = ["--json", *config_args]
+            args = ["--skip-unknown-extensions", "--json", *config_args]
             for path in chunk:
-                args.extend(["--include", path])
+                args.append(path)
             findings.current.update(
                 Finding.from_semgrep_result(result, ctx)
                 for result in json.loads(str(semgrep(*args)))["results"]


### PR DESCRIPTION
With --skip-unknown-extension flag in semgrep 0.20.0 we can pass
explicit files directly to semgrep without running into issue of
semgrep running all explicitly passed files on all rules.

This makes semgrep aaction run as fast as semgrep locally since it
no longer needs to traverse the file tree with the --include passing

Closes https://github.com/returntocorp/semgrep-action/issues/35