### PR TITLE
Check if file exists before git rm

### DIFF
--- a/src/semgrep_agent/targets.py
+++ b/src/semgrep_agent/targets.py
@@ -260,7 +260,9 @@ class TargetFileManager:
                     raise error
 
             if self._status.removed:
-                git.rm("-f", *(str(r) for r in self._status.removed))
+                # Need to check if file exists since it is possible file was deleted
+                # in both the base and head
+                git.rm("-f", *(str(r) for r in self._status.removed if r.exists()))
 
     @contextmanager
     def baseline_paths(self) -> Iterator[List[Path]]:


### PR DESCRIPTION
Users were running into issue where the file being git rm-ed was not there anymore:

Error message contained `fatal: pathspec '<some path>' did not match any files`

Checking with user it looks like the file was deleted between base and head but another PR was added to base that also removed the file so the new base did not contain the file anymore.