### PR TITLE
Use file targeting instead of include for checking pre-existing issues

### DIFF
--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -156,9 +156,9 @@ def invoke_semgrep(ctx: click.Context) -> FindingSets:
                     + unit_len(paths_to_check, "file")
                 )
                 for chunk in chunked_iter(paths_to_check, PATHS_CHUNK_SIZE):
-                    args = ["--json", *config_args]
+                    args = ["--skip-unknown-extensions", "--json", *config_args]
                     for path in chunk:
-                        args.extend(["--include", path])
+                        args.append(path)
                     findings.baseline.update(
                         Finding.from_semgrep_result(result, ctx)
                         for result in json.loads(str(semgrep(*args)))["results"]


### PR DESCRIPTION
Similar to 11ee1a6f37fbf232b3f39afc97fce12f4b854057, we should also use file targeting for checking pre-existing issues to improve performance.