### PR TITLE
refactor: explicitly pass args instead of passing ctx object

### DIFF
--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -73,7 +73,7 @@ class Finding:
 
     @classmethod
     def from_semgrep_result(
-        cls, result: Dict[str, Any], ctx: click.Context
+        cls, result: Dict[str, Any], committed_datetime: Optional[datetime]
     ) -> "Finding":
         return cls(
             check_id=result["check_id"],
@@ -85,9 +85,7 @@ class Finding:
             message=result["extra"]["message"],
             severity=cls.semgrep_severity_to_int(result["extra"]["severity"]),
             syntactic_context=result["extra"]["lines"],
-            commit_date=ctx.obj.meta.commit.committed_datetime
-            if ctx.obj.meta.commit
-            else None,
+            commit_date=committed_datetime,
             metadata=result["extra"]["metadata"],
         )
 

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -54,9 +54,7 @@ def get_event_type() -> str:
 @click.option("--publish-token", envvar="INPUT_PUBLISHTOKEN", type=str)
 @click.option("--publish-deployment", envvar="INPUT_PUBLISHDEPLOYMENT", type=int)
 @click.option("--json", "json_output", hidden=True, is_flag=True)
-@click.pass_context
 def main(
-    ctx: click.Context,
     config: str,
     baseline_ref: str,
     publish_url: str,
@@ -72,48 +70,42 @@ def main(
         err=True,
     )
 
+    # Get Metadata
     Meta = detect_meta_environment()
     meta_kwargs = {}
     if baseline_ref:
         meta_kwargs["cli_baseline_ref"] = baseline_ref
+    meta = Meta(config, **meta_kwargs)
 
-    obj = ctx.obj = CliObj(
-        event_type=get_event_type(),
-        config=config,
-        meta=Meta(ctx, **meta_kwargs),
-        sapp=Sapp(
-            ctx=ctx,
-            url=publish_url,
-            token=publish_token,
-            deployment_id=publish_deployment,
-        ),
-    )
+    sapp = Sapp(url=publish_url, token=publish_token, deployment_id=publish_deployment)
+
     click.echo(
         f"| environment - "
-        f"running in {obj.meta.environment}, "
-        f"triggering event is '{obj.meta.event_name}'",
+        f"running in {meta.environment}, "
+        f"triggering event is '{meta.event_name}'",
         err=True,
     )
 
-    if obj.sapp.is_configured:
+    if sapp.is_configured:
         click.echo(
-            f"| semgrep.dev - logged in as deployment #{obj.sapp.deployment_id}",
-            err=True,
+            f"| semgrep.dev - logged in as deployment #{sapp.deployment_id}", err=True,
         )
     else:
         click.echo("| semgrep.dev - not logged in", err=True)
 
-    maybe_print_debug_info(obj.meta)
+    maybe_print_debug_info(meta)
 
-    obj.sapp.report_start()
+    sapp.report_start(meta)
 
     click.echo("=== setting up agent configuration", err=True)
-    if obj.config:
-        click.echo(f"| using semgrep rules from {obj.config}", err=True)
-    elif obj.sapp.is_configured:
+    if config:
+        click.echo(f"| using semgrep rules from {config}", err=True)
+    elif sapp.is_configured:
         click.echo("| using semgrep rules configured on the web UI", err=True)
+        # TODO setup config
     elif Path(".semgrep.yml").is_file():
         click.echo("| using semgrep rules from the committed .semgrep.yml", err=True)
+        # TODO config = .semgrep.yml
     else:
         message = """
             == [ERROR] you didn't configure what rules semgrep should scan for.
@@ -126,7 +118,13 @@ def main(
         click.echo(message, err=True)
         sys.exit(1)
 
-    results = semgrep.scan(ctx)
+    committed_datetime = meta.commit.committed_datetime if meta.commit else None
+    results = semgrep.scan(
+        config,
+        committed_datetime,
+        meta.base_commit_ref,
+        semgrep.get_semgrepignore(sapp.scan.ignore_patterns),
+    )
     new_findings = results.findings.new
 
     blocking_findings = {finding for finding in new_findings if finding.is_blocking()}
@@ -148,7 +146,7 @@ def main(
             err=True,
         )
 
-    obj.sapp.report_results(results)
+    sapp.report_results(results)
 
     exit_code = 1 if blocking_findings else 0
     click.echo(

--- a/src/semgrep_agent/meta.py
+++ b/src/semgrep_agent/meta.py
@@ -10,7 +10,6 @@ from typing import Optional
 from typing import Type
 from typing import Union
 
-import click
 import git as gitpython
 import sh
 from boltons.cacheutils import cachedproperty
@@ -26,7 +25,7 @@ from semgrep_agent.utils import debug_echo
 class GitMeta:
     """Gather metadata only from local filesystem."""
 
-    ctx: click.Context
+    config: str
     cli_baseline_ref: Optional[str] = None
     environment: str = field(default="git", init=False)
 
@@ -72,7 +71,7 @@ class GitMeta:
             "commit_author_image_url": None,
             "commit_authored_timestamp": self.commit.authored_datetime.isoformat(),
             "commit_title": self.commit.summary,
-            "config": self.ctx.obj.config,
+            "config": self.config,
             "on": self.event_name,
             "branch": None,
             "pull_request_timestamp": None,

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -52,19 +52,6 @@ def resolve_config_shorthand(config: str) -> str:
         return config
 
 
-@contextmanager
-def get_semgrep_config(ctx: click.Context) -> Iterator[List[Union[str, Path]]]:
-    if ctx.obj.config:
-        yield ["--config", resolve_config_shorthand(ctx.obj.config)]
-    elif ctx.obj.sapp.is_configured:
-        local_config_path = Path(".tmp-semgrep.yml")
-        local_config_path.symlink_to(ctx.obj.sapp.download_rules())
-        yield ["--config", local_config_path]
-        local_config_path.unlink()
-    else:
-        yield []
-
-
 def get_semgrepignore(ignore_patterns: List[str]) -> TextIO:
     semgrepignore = io.StringIO()
     TEMPLATES_DIR = (Path(__file__).parent / "templates").resolve()

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -6,6 +6,7 @@ import time
 import urllib.parse
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
 from textwrap import indent
@@ -54,7 +55,6 @@ def resolve_config_shorthand(config: str) -> str:
 @contextmanager
 def get_semgrep_config(ctx: click.Context) -> Iterator[List[Union[str, Path]]]:
     if ctx.obj.config:
-        rules_url = resolve_config_shorthand(ctx.obj.config)
         yield ["--config", resolve_config_shorthand(ctx.obj.config)]
     elif ctx.obj.sapp.is_configured:
         local_config_path = Path(".tmp-semgrep.yml")
@@ -65,7 +65,7 @@ def get_semgrep_config(ctx: click.Context) -> Iterator[List[Union[str, Path]]]:
         yield []
 
 
-def get_semgrepignore(scan: "Scan") -> TextIO:
+def get_semgrepignore(ignore_patterns: List[str]) -> TextIO:
     semgrepignore = io.StringIO()
     TEMPLATES_DIR = (Path(__file__).parent / "templates").resolve()
 
@@ -80,13 +80,12 @@ def get_semgrepignore(scan: "Scan") -> TextIO:
         )
         semgrepignore.write((TEMPLATES_DIR / ".semgrepignore").read_text())
 
-    scan_patterns = scan.ignore_patterns
-    if scan_patterns:
+    if ignore_patterns:
         click.echo(
             "| adding further path ignore rules configured on the web UI", err=True
         )
         semgrepignore.write("\n# Ignores from semgrep app\n")
-        semgrepignore.write("\n".join(scan_patterns))
+        semgrepignore.write("\n".join(ignore_patterns))
         semgrepignore.write("\n")
 
     return semgrepignore
@@ -120,21 +119,28 @@ def rewrite_sarif_file(sarif_path: Path) -> None:
         json.dump(sarif_results, sarif_file, indent=2, sort_keys=True)
 
 
-def invoke_semgrep(ctx: click.Context) -> FindingSets:
+def invoke_semgrep(
+    config_specifier: str,
+    committed_datetime: Optional[datetime],
+    base_commit_ref: Optional[str],
+    semgrep_ignore: TextIO,
+) -> FindingSets:
     debug_echo("=== adding semgrep configuration")
 
     workdir = Path.cwd()
     targets = TargetFileManager(
         base_path=workdir,
-        base_commit=ctx.obj.meta.base_commit_ref,
+        base_commit=base_commit_ref,
         paths=[workdir],
-        ignore_rules_file=get_semgrepignore(ctx.obj.sapp.scan),
+        ignore_rules_file=semgrep_ignore,
     )
+
+    config_args = ["--config", config_specifier]
 
     debug_echo("=== seeing if there are any findings")
     findings = FindingSets()
 
-    with targets.current_paths() as paths, get_semgrep_config(ctx) as config_args:
+    with targets.current_paths() as paths:
         click.echo(
             "=== looking for current issues in " + unit_len(paths, "file"), err=True
         )
@@ -143,7 +149,7 @@ def invoke_semgrep(ctx: click.Context) -> FindingSets:
             for path in chunk:
                 args.append(path)
             findings.current.update(
-                Finding.from_semgrep_result(result, ctx)
+                Finding.from_semgrep_result(result, committed_datetime)
                 for result in json.loads(str(semgrep(*args)))["results"]
             )
             click.echo(
@@ -156,7 +162,7 @@ def invoke_semgrep(ctx: click.Context) -> FindingSets:
             err=True,
         )
     else:
-        with targets.baseline_paths() as paths, get_semgrep_config(ctx) as config_args:
+        with targets.baseline_paths() as paths:
             if paths:
                 paths_with_findings = {finding.path for finding in findings.current}
                 paths_to_check = set(str(path) for path in paths) & paths_with_findings
@@ -170,7 +176,7 @@ def invoke_semgrep(ctx: click.Context) -> FindingSets:
                     for path in chunk:
                         args.append(path)
                     findings.baseline.update(
-                        Finding.from_semgrep_result(result, ctx)
+                        Finding.from_semgrep_result(result, committed_datetime)
                         for result in json.loads(str(semgrep(*args)))["results"]
                     )
                 click.echo(
@@ -182,9 +188,7 @@ def invoke_semgrep(ctx: click.Context) -> FindingSets:
         # FIXME: This will crash when running on thousands of files due to command length limit
         click.echo("=== re-running scan to generate a SARIF report", err=True)
         sarif_path = Path("semgrep.sarif")
-        with targets.current_paths() as paths, sarif_path.open(
-            "w"
-        ) as sarif_file, get_semgrep_config(ctx) as config_args:
+        with targets.current_paths() as paths, sarif_path.open("w") as sarif_file:
             args = ["--sarif", *config_args]
             for path in paths:
                 args.extend(["--include", path])
@@ -194,12 +198,17 @@ def invoke_semgrep(ctx: click.Context) -> FindingSets:
     return findings
 
 
-def scan(ctx: click.Context) -> Results:
-    meta = ctx.obj.meta
-
+def scan(
+    config_specifier: str,
+    committed_datetime: Optional[datetime],
+    base_commit_ref: Optional[str],
+    semgrep_ignore: TextIO,
+) -> Results:
     before = time.time()
     try:
-        findings = invoke_semgrep(ctx)
+        findings = invoke_semgrep(
+            config_specifier, committed_datetime, base_commit_ref, semgrep_ignore
+        )
     except sh.ErrorReturnCode as error:
         message = f"""
         === failed command's STDOUT:

--- a/src/semgrep_agent/targets.py
+++ b/src/semgrep_agent/targets.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Iterator
 from typing import List
 from typing import NamedTuple
+from typing import Optional
 from typing import TextIO
 from typing import TYPE_CHECKING
 
@@ -67,7 +68,7 @@ class TargetFileManager:
     _base_path = attr.ib(type=Path)
     _paths = attr.ib(type=List[Path])
     _ignore_rules_file = attr.ib(type=TextIO)
-    _base_commit = attr.ib(type=str, default=None)
+    _base_commit = attr.ib(type=Optional[str], default=None)
     _status = attr.ib(type=GitStatus, init=False)
     _target_paths = attr.ib(type=List[Path], init=False)
 


### PR DESCRIPTION
Using ctx object as a global made it hard to reason about behavior.

This PR explicitly passes necessary arguments to function instead of passing
the ctx object as a whole.