### PR TITLE
fix: local config messing with git cleanliness

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -100,8 +100,7 @@ def main(
         config = semgrep.resolve_config_shorthand(config)
         click.echo(f"| using semgrep rules from {config}", err=True)
     elif sapp.is_configured:
-        local_config_path = Path(".tmp-semgrep.yml")
-        local_config_path.symlink_to(sapp.download_rules())
+        local_config_path = sapp.download_rules()
         config = str(local_config_path)
         click.echo("| using semgrep rules configured on the web UI", err=True)
     elif Path(".semgrep.yml").is_file():


### PR DESCRIPTION
After refactor PR local config file when running on semgrep teams
leaves the config in the git directory causing an error when
checking for a clean git repo. This PR no longer makes a local
copy of the downloaded config and points to file downloaded to /tmp