### PR TITLE
Add finding index to findings hash

### DIFF
--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -6,10 +6,11 @@ from dataclasses import field
 from datetime import datetime
 from typing import Any
 from typing import Dict
-from typing import Mapping
 from typing import List
+from typing import Mapping
 from typing import Optional
 from typing import Set
+from typing import Tuple
 
 import attr
 import pymmh3
@@ -81,15 +82,13 @@ class Finding:
     @classmethod
     def from_semgrep_result(
         cls, result: Dict[str, Any], committed_datetime: Optional[datetime]
-    ) -> (FindingKey, "Finding"):
+    ) -> Tuple[FindingKey, "Finding"]:
         check_id = result["check_id"]
         path = result["path"]
         syntactic_context = result["extra"]["lines"]
 
         key = FindingKey(
-            check_id=check_id,
-            path=path,
-            syntactic_context=syntactic_context,
+            check_id=check_id, path=path, syntactic_context=syntactic_context,
         )
         finding = cls(
             check_id=check_id,
@@ -124,7 +123,7 @@ class FindingSets:
         return self.current_set() - self.baseline_set()
 
     @staticmethod
-    def _map_to_set(mapping: Mapping[FindingKey, List[Finding]]):
+    def _map_to_set(mapping: Mapping[FindingKey, List[Finding]]) -> Set[Finding]:
         return set(
             attr.evolve(f, index=ix)
             for ff in mapping.values()

--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -125,9 +125,9 @@ class FindingSets:
     @staticmethod
     def _map_to_set(mapping: Mapping[FindingKey, List[Finding]]) -> Set[Finding]:
         return set(
-            attr.evolve(f, index=ix)
-            for ff in mapping.values()
-            for ix, f in enumerate(ff)
+            attr.evolve(finding, index=index)
+            for findings_for_key in mapping.values()
+            for index, finding in enumerate(findings_for_key)
         )
 
     def current_set(self) -> Set[Finding]:

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -126,7 +126,7 @@ def main(
         meta.base_commit_ref,
         semgrep.get_semgrepignore(sapp.scan.ignore_patterns),
     )
-    new_findings = results.findings.new
+    new_findings = results.findings.expensive_new()
 
     blocking_findings = {finding for finding in new_findings if finding.is_blocking()}
 

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -126,20 +126,19 @@ def main(
         meta.base_commit_ref,
         semgrep.get_semgrepignore(sapp.scan.ignore_patterns),
     )
-    new_findings = results.findings.expensive_new()
 
-    blocking_findings = {finding for finding in new_findings if finding.is_blocking()}
+    blocking_findings = {finding for finding in results.new if finding.is_blocking()}
 
     if json_output:
         # Output all new findings as json
-        output = [f.to_dict() for f in new_findings]
+        output = [f.to_dict() for f in results.new]
         click.echo(json.dumps(output))
     else:
         # Print out blocking findings
         formatter.dump(blocking_findings)
 
     non_blocking_findings = {
-        finding for finding in new_findings if not finding.is_blocking()
+        finding for finding in results.new if not finding.is_blocking()
     }
     if non_blocking_findings:
         click.echo(

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -5,7 +5,6 @@ import sys
 import time
 import urllib.parse
 from contextlib import contextmanager
-from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
@@ -19,14 +18,15 @@ from typing import TextIO
 from typing import TYPE_CHECKING
 from typing import Union
 
+import attr
 import click
 import requests
 import sh
 from boltons.iterutils import chunked_iter
-from boltons.strutils import unit_len
+from boltons.strutils import cardinalize, unit_len
 from sh.contrib import git
 
-from semgrep_agent.findings import Finding
+from semgrep_agent.findings import Finding, FindingKey
 from semgrep_agent.findings import FindingSets
 from semgrep_agent.meta import GitMeta
 from semgrep_agent.targets import TargetFileManager
@@ -78,15 +78,19 @@ def get_semgrepignore(ignore_patterns: List[str]) -> TextIO:
     return semgrepignore
 
 
-@dataclass
-class Results:
-    findings: FindingSets
-    total_time: float
+@attr.s(frozen=True)
+class Results(object):
+    findings = attr.ib(type=FindingSets)
+    total_time = attr.ib(type=float)
+    new = attr.ib(type=set, init=False)
+
+    def __attrs_post_init__(self):
+        object.__setattr__(self, "new", self.findings.expensive_new())
 
     @property
     def stats(self) -> Dict[str, Any]:
         return {
-            "findings": len(self.findings.new),
+            "findings": len(self.new),
             "total_time": self.total_time,
         }
 
@@ -104,6 +108,16 @@ def rewrite_sarif_file(sarif_path: Path) -> None:
 
     with sarif_path.open("w") as sarif_file:
         json.dump(sarif_results, sarif_file, indent=2, sort_keys=True)
+
+
+def _update_finding_set(
+    result: Dict[str, Any], committed_datetime: Optional[datetime],
+    findingsMap: Dict[FindingKey, List[Finding]]
+) -> None:
+    key, finding = Finding.from_semgrep_result(result, committed_datetime)
+    forKey = findingsMap.get(key, [])
+    forKey.append(finding)
+    findingsMap[key] = forKey
 
 
 def invoke_semgrep(
@@ -125,7 +139,7 @@ def invoke_semgrep(
     config_args = ["--config", config_specifier]
 
     debug_echo("=== seeing if there are any findings")
-    findings = FindingSets()
+    findingSet = FindingSets()
 
     with targets.current_paths() as paths:
         click.echo(
@@ -135,15 +149,15 @@ def invoke_semgrep(
             args = ["--skip-unknown-extensions", "--json", *config_args]
             for path in chunk:
                 args.append(path)
-            findings.current.update(
-                Finding.from_semgrep_result(result, committed_datetime)
-                for result in json.loads(str(semgrep(*args)))["results"]
-            )
+            count = 0
+            for result in json.loads(str(semgrep(*args)))["results"]:
+                _update_finding_set(result, committed_datetime, findingSet.current_map)
+                count += 1
             click.echo(
-                f"| {unit_len(findings.current, 'current issue')} found", err=True
+                f"| {count} {cardinalize('current issue', count)} found", err=True
             )
 
-    if not findings.current:
+    if not findingSet.current_map:
         click.echo(
             "=== not looking at pre-existing issues since there are no current issues",
             err=True,
@@ -151,7 +165,7 @@ def invoke_semgrep(
     else:
         with targets.baseline_paths() as paths:
             if paths:
-                paths_with_findings = {finding.path for finding in findings.current}
+                paths_with_findings = {finding.path for finding in findingSet.current_map.keys()}
                 paths_to_check = set(str(path) for path in paths) & paths_with_findings
                 click.echo(
                     "=== looking for pre-existing issues in "
@@ -162,12 +176,12 @@ def invoke_semgrep(
                     args = ["--skip-unknown-extensions", "--json", *config_args]
                     for path in chunk:
                         args.append(path)
-                    findings.baseline.update(
-                        Finding.from_semgrep_result(result, committed_datetime)
-                        for result in json.loads(str(semgrep(*args)))["results"]
-                    )
+                    count = 0
+                    for result in json.loads(str(semgrep(*args)))["results"]:
+                        _update_finding_set(result, committed_datetime, findingSet.baseline_map)
+                        count += 1
                 click.echo(
-                    f"| {unit_len(findings.baseline, 'pre-existing issue')} found",
+                    f"| {count} {cardinalize('pre-existing issue', count)} found",
                     err=True,
                 )
 
@@ -182,7 +196,7 @@ def invoke_semgrep(
             semgrep(*args, _out=sarif_file)
         rewrite_sarif_file(sarif_path)
 
-    return findings
+    return findingSet
 
 
 def scan(

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -23,10 +23,12 @@ import click
 import requests
 import sh
 from boltons.iterutils import chunked_iter
-from boltons.strutils import cardinalize, unit_len
+from boltons.strutils import cardinalize
+from boltons.strutils import unit_len
 from sh.contrib import git
 
-from semgrep_agent.findings import Finding, FindingKey
+from semgrep_agent.findings import Finding
+from semgrep_agent.findings import FindingKey
 from semgrep_agent.findings import FindingSets
 from semgrep_agent.meta import GitMeta
 from semgrep_agent.targets import TargetFileManager
@@ -84,7 +86,7 @@ class Results(object):
     total_time = attr.ib(type=float)
     new = attr.ib(type=set, init=False)
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         object.__setattr__(self, "new", self.findings.expensive_new())
 
     @property
@@ -111,8 +113,9 @@ def rewrite_sarif_file(sarif_path: Path) -> None:
 
 
 def _update_finding_set(
-    result: Dict[str, Any], committed_datetime: Optional[datetime],
-    findingsMap: Dict[FindingKey, List[Finding]]
+    result: Dict[str, Any],
+    committed_datetime: Optional[datetime],
+    findingsMap: Dict[FindingKey, List[Finding]],
 ) -> None:
     key, finding = Finding.from_semgrep_result(result, committed_datetime)
     forKey = findingsMap.get(key, [])
@@ -165,7 +168,9 @@ def invoke_semgrep(
     else:
         with targets.baseline_paths() as paths:
             if paths:
-                paths_with_findings = {finding.path for finding in findingSet.current_map.keys()}
+                paths_with_findings = {
+                    finding.path for finding in findingSet.current_map.keys()
+                }
                 paths_to_check = set(str(path) for path in paths) & paths_with_findings
                 click.echo(
                     "=== looking for pre-existing issues in "
@@ -178,7 +183,9 @@ def invoke_semgrep(
                         args.append(path)
                     count = 0
                     for result in json.loads(str(semgrep(*args)))["results"]:
-                        _update_finding_set(result, committed_datetime, findingSet.baseline_map)
+                        _update_finding_set(
+                            result, committed_datetime, findingSet.baseline_map
+                        )
                         count += 1
                 click.echo(
                     f"| {count} {cardinalize('pre-existing issue', count)} found",

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -87,6 +87,7 @@ class Results(object):
     new = attr.ib(type=set, init=False)
 
     def __attrs_post_init__(self) -> None:
+        # Since class is frozen we must use object.__setattr__ (per attrs documentation)
         object.__setattr__(self, "new", self.findings.expensive_new())
 
     @property

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -103,7 +103,7 @@ class Sapp:
         debug_echo(f"=== reporting results to semgrep app at {self.url}")
 
         # report findings
-        for chunk in chunked_iter(results.findings.new, 10_000):
+        for chunk in chunked_iter(results.new, 10_000):
             response = self.session.post(
                 f"{self.url}/api/agent/scan/{self.scan.id}/findings",
                 json=[finding.to_dict() for finding in chunk],


### PR DESCRIPTION
In order to not trigger a new finding on whitespace changes and line
moves, we exclude surrounding context data from findings hashes.
However, this means that duplicate results with the exact same code in
a file will show up as only one finding, which is not desirable.

Here, we include the index of a finding within the file, so these show
up as separate findings.

This was tested by committing a "bad.py" with:
```
  5 == 5
```
Then committing an edit to that file to read:
```
  5 == 5

  5 == 5
```
We validated that the agent found 2 findings in the second commit, and
1 new finding when comparing the second commit to the first.

I then validated the finding number sent to the backend with:
```
    semgrep-agent \
      --config r/python.lang.correctness.useless-eqeq.useless-eqeq \
      --baseline-ref head^^ \
      --publish-url "https://dev.semgrep.dev" \
      --publish-token '********' \
      --publish-deployment 1
```

Fixes #56 