### PR TITLE
Protect against "expected" errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ attrs = "~=19.3.0"
 [tool.poetry.dev-dependencies]
 
 [tool.poetry.scripts]
-semgrep-agent = "semgrep_agent.__main__:main"
+semgrep-agent = "semgrep_agent.__main__:error_guard"
 
 [build-system]
 requires = ["poetry>=1.0.10"]

--- a/src/semgrep_agent/__main__.py
+++ b/src/semgrep_agent/__main__.py
@@ -1,4 +1,18 @@
+import sys
+
+import click
+
 from semgrep_agent.main import main
+from semgrep_agent.utils import ActionFailure
+
+
+def error_guard() -> None:
+    try:
+        main()
+    except ActionFailure as ex:
+        click.secho(ex.message, fg="red", err=True)
+        sys.exit(1)
+
 
 if __name__ == "__main__":
-    main()
+    error_guard()

--- a/src/semgrep_agent/constants.py
+++ b/src/semgrep_agent/constants.py
@@ -1,1 +1,3 @@
+SUPPORT_EMAIL = "support@r2c.dev"
+
 PRIVACY_SENSITIVE_FIELDS = {"syntactic_context"}

--- a/src/semgrep_agent/utils.py
+++ b/src/semgrep_agent/utils.py
@@ -15,6 +15,15 @@ if TYPE_CHECKING:
     from semgrep_agent.meta import GitMeta
 
 
+class ActionFailure(Exception):
+    """
+    Indicates that Semgrep failed and should abort, but prevents a stack trace
+    """
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+
 def debug_echo(text: str) -> None:
     """Print debug messages with context-specific debug formatting."""
     if os.getenv("GITHUB_ACTIONS"):


### PR DESCRIPTION
We don't want to spam stack traces for problems that are
client-generated, or due to a backend failure, as we don't need to debug
the application in those cases. Collect these under an error guard at
the top level.

Fixes #57 