### PR TITLE
Support setting rules in a committed .semgrep/ directory

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -106,6 +106,11 @@ def main(
     elif Path(".semgrep.yml").is_file():
         click.echo("| using semgrep rules from the committed .semgrep.yml", err=True)
         config = ".semgrep.yml"
+    elif Path(".semgrep").is_dir():
+        click.echo(
+            "| using semgrep rules from the committed .semgrep/ directory", err=True
+        )
+        config = ".semgrep/"
     else:
         message = """
             == [ERROR] you didn't configure what rules semgrep should scan for.


### PR DESCRIPTION
Changes were tested by:

1. Committing a bad.py with `5 == 5` in a repo.
2. Verifying that

     python -m semgrep_agent --baseline-ref HEAD~1

   returns a missing config error.
3. Committing a .semgrep/eqeq.yml rule to the repo.
4. Verifying that

     python -m semgrep_agent --baseline-ref HEAD~2

   returns a finding for the `5 == 5` line.

Closes https://github.com/returntocorp/semgrep-action/issues/61