### PR TITLE
ignore .semgrep folder by default

### DIFF
--- a/src/semgrep_agent/templates/.semgrepignore
+++ b/src/semgrep_agent/templates/.semgrepignore
@@ -17,3 +17,6 @@ venv/
 # Common test directories
 test/
 tests/
+
+# Semgrep rules folder
+.semgrep


### PR DESCRIPTION
Reason: .semgrep folder will contain folders with rules, and potential tests. It would be good if we can ignore the .semgrep rules folder by default.