### PR TITLE
Avoid 'set-env' and use automatic caching

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,14 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
-      - name: set PY
-        run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      - uses: pre-commit/action@v1.0.1
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0
 
   semgrep:
     name: semgrep with managed policy


### PR DESCRIPTION
Remove `set-env` due to https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w. The latest `pre-commit` Action also automatically handles caching (https://github.com/pre-commit/action/releases/tag/v2.0.0), so we don't need this anyway.