### PR TITLE
Add '--no-rewrite-rule-ids' to Semgrep runs to fix 'nosem' functionality

### DIFF
--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -75,13 +75,10 @@ class Finding:
 
     @classmethod
     def from_semgrep_result(
-        cls,
-        result: Dict[str, Any],
-        committed_datetime: Optional[datetime],
-        rules_path_len: int,
+        cls, result: Dict[str, Any], committed_datetime: Optional[datetime],
     ) -> "Finding":
         return cls(
-            check_id=result["check_id"][rules_path_len:],
+            check_id=result["check_id"],
             path=result["path"],
             line=result["start"]["line"],
             column=result["start"]["col"],

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -137,7 +137,12 @@ def invoke_semgrep(
             "=== looking for current issues in " + unit_len(paths, "file"), err=True
         )
         for chunk in chunked_iter(paths, PATHS_CHUNK_SIZE):
-            args = ["--skip-unknown-extensions", "--json", *config_args]
+            args = [
+                "--skip-unknown-extensions",
+                "--json",
+                "--no-rewrite-rule-ids",
+                *config_args,
+            ]
             for path in chunk:
                 args.append(path)
             semgrep_results = json.loads(str(semgrep(*args)))["results"]
@@ -165,7 +170,12 @@ def invoke_semgrep(
                     err=True,
                 )
                 for chunk in chunked_iter(paths_to_check, PATHS_CHUNK_SIZE):
-                    args = ["--skip-unknown-extensions", "--json", *config_args]
+                    args = [
+                        "--skip-unknown-extensions",
+                        "--json",
+                        "--no-rewrite-rule-ids",
+                        *config_args,
+                    ]
                     for path in chunk:
                         args.append(path)
                     semgrep_results = json.loads(str(semgrep(*args)))["results"]
@@ -185,7 +195,7 @@ def invoke_semgrep(
         click.echo("=== re-running scan to generate a SARIF report", err=True)
         sarif_path = Path("semgrep.sarif")
         with targets.current_paths() as paths, sarif_path.open("w") as sarif_file:
-            args = ["--sarif", *config_args]
+            args = ["--sarif", "--no-rewrite-rule-ids", *config_args]
             for path in paths:
                 args.extend(["--include", path])
             semgrep(*args, _out=sarif_file)

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -128,9 +128,6 @@ def invoke_semgrep(
 
     debug_echo("=== seeing if there are any findings")
     findings = FindingSets()
-    rules_path_len = (
-        len(os.path.dirname(config_specifier)) if uses_managed_policy else 0
-    )
 
     with targets.current_paths() as paths:
         click.echo(
@@ -147,7 +144,7 @@ def invoke_semgrep(
                 args.append(path)
             semgrep_results = json.loads(str(semgrep(*args)))["results"]
             findings.current.update_findings(
-                Finding.from_semgrep_result(result, committed_datetime, rules_path_len)
+                Finding.from_semgrep_result(result, committed_datetime)
                 for result in semgrep_results
             )
             click.echo(
@@ -180,9 +177,7 @@ def invoke_semgrep(
                         args.append(path)
                     semgrep_results = json.loads(str(semgrep(*args)))["results"]
                     findings.baseline.update_findings(
-                        Finding.from_semgrep_result(
-                            result, committed_datetime, rules_path_len
-                        )
+                        Finding.from_semgrep_result(result, committed_datetime)
                         for result in semgrep_results
                     )
                 click.echo(

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -125,6 +125,7 @@ def invoke_semgrep(
     )
 
     config_args = ["--config", config_specifier]
+    rewrite_args = ["--no-rewrite-rule-ids"] if uses_managed_policy else []
 
     debug_echo("=== seeing if there are any findings")
     findings = FindingSets()
@@ -137,7 +138,7 @@ def invoke_semgrep(
             args = [
                 "--skip-unknown-extensions",
                 "--json",
-                "--no-rewrite-rule-ids",
+                *rewrite_args,
                 *config_args,
             ]
             for path in chunk:
@@ -170,7 +171,7 @@ def invoke_semgrep(
                     args = [
                         "--skip-unknown-extensions",
                         "--json",
-                        "--no-rewrite-rule-ids",
+                        *rewrite_args,
                         *config_args,
                     ]
                     for path in chunk:
@@ -190,7 +191,7 @@ def invoke_semgrep(
         click.echo("=== re-running scan to generate a SARIF report", err=True)
         sarif_path = Path("semgrep.sarif")
         with targets.current_paths() as paths, sarif_path.open("w") as sarif_file:
-            args = ["--sarif", "--no-rewrite-rule-ids", *config_args]
+            args = ["--sarif", *rewrite_args, *config_args]
             for path in paths:
                 args.extend(["--include", path])
             semgrep(*args, _out=sarif_file)


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/2033.

Before:

```go
func conn() grpc.ClientConnInterface {
	cc, err := grpc.Dial("localhost:1234", grpc.WithInsecure())
	if err != nil {
		panic(err)
	}
	return cc
}
```

```
$ python -m semgrep_agent --publish-deployment ... --publish-token ... 
...
go.grpc.security.grpc-client-insecure-connection.grpc-client-insecure-connection
     > test.go:2
     ╷
    2│   cc, err := grpc.Dial("localhost:1234", grpc.WithInsecure())
     ╵
     = Found an insecure gRPC connection. This creates a connection without
       encryption to a gRPC server. A malicious attacker could tamper with the
       gRPC message, which could compromise the machine.

=== exiting with failing status
```

```go
func conn() grpc.ClientConnInterface {
	cc, err := grpc.Dial("localhost:1234", grpc.WithInsecure()) // nosem: go.grpc.security.grpc-client-insecure-connection.grpc-client-insecure-connection
	if err != nil {
		panic(err)
	}
	return cc
}
```

```
$ python -m semgrep_agent --publish-deployment ... --publish-token ... 
...
| No current issues found
=== not looking at pre-existing issues since there are no current issues
=== exiting with success status
```