### PR TITLE
Add environment variables to displayed commandline output

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -88,11 +88,12 @@ def main(
     # Setup URL/Token
     sapp = Sapp(url=publish_url, token=publish_token, deployment_id=publish_deployment)
     maybe_print_debug_info(meta)
-    sapp.report_start(meta)
+    policy = sapp.report_start(meta)
     if sapp.is_configured:
         click.echo(
             f"| {server} - logged in as deployment #{sapp.deployment_id}", err=True,
         )
+        click.echo(f"| using policy {policy}")
     else:
         click.echo(f"| {server} - not logged in", err=True)
 

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -72,7 +72,7 @@ def main(
     )
 
     # Get Metadata
-    server = os.getenv("INPUT_PUBLISHURL") or "https://semgrep.dev"
+    # server = os.getenv("INPUT_PUBLISHURL") or "https://semgrep.dev"
     Meta = detect_meta_environment()
     meta_kwargs = {}
     if baseline_ref:
@@ -90,15 +90,22 @@ def main(
     maybe_print_debug_info(meta)
     policy = sapp.report_start(meta)
     if sapp.is_configured:
-        click.echo(
-            f"| {server} - logged in as deployment #{sapp.deployment_id}", err=True,
-        )
+        if publish_url == "https://semgrep.dev":
+            click.echo(
+                f"| Semgrep Community - logged in as deployment #{sapp.deployment_id}",
+                err=True,
+            )
+        else:
+            click.echo(
+                f"| Semgrep Community - logged in to {publish_url} as deployment #{sapp.deployment_id}",
+                err=True,
+            )
         if policy:
             click.echo(f"| policy - using {policy}")
         else:
             click.echo(f"| policy - unknown")
     else:
-        click.echo(f"| {server} - not logged in", err=True)
+        click.echo(f"| Semgrep Community - not logged in", err=True)
 
     for env_var in [
         "SEMGREP_REPO_URL",
@@ -108,7 +115,7 @@ def main(
         "SEMGREP_PR_TITLE",
     ]:
         if os.getenv(env_var):
-            click.echo(f"| {env_var}={os.getenv(env_var)}")
+            click.echo(f"| {env_var} - {os.getenv(env_var)}")
 
     # Setup Config
     click.echo("=== setting up agent configuration", err=True)

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -93,7 +93,8 @@ def main(
         click.echo(
             f"| {server} - logged in as deployment #{sapp.deployment_id}", err=True,
         )
-        click.echo(f"| using policy {policy}")
+        if policy:
+            click.echo(f"| using policy {policy}")
     else:
         click.echo(f"| {server} - not logged in", err=True)
 

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -72,6 +72,7 @@ def main(
     )
 
     # Get Metadata
+    server = os.getenv("INPUT_PUBLISHURL") or "https://semgrep.dev"
     Meta = detect_meta_environment()
     meta_kwargs = {}
     if baseline_ref:
@@ -90,10 +91,20 @@ def main(
     sapp.report_start(meta)
     if sapp.is_configured:
         click.echo(
-            f"| semgrep.dev - logged in as deployment #{sapp.deployment_id}", err=True,
+            f"| {server} - logged in as deployment #{sapp.deployment_id}", err=True,
         )
     else:
-        click.echo("| semgrep.dev - not logged in", err=True)
+        click.echo(f"| {server} - not logged in", err=True)
+
+    for env_var in [
+        "SEMGREP_REPO_URL",
+        "SEMGREP_JOB_URL",
+        "SEMGREP_BRANCH",
+        "SEMGREP_PR_ID",
+        "SEMGREP_PR_TITLE",
+    ]:
+        if os.getenv(env_var):
+            click.echo(f"| {env_var}={os.getenv(env_var)}")
 
     # Setup Config
     click.echo("=== setting up agent configuration", err=True)

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -94,7 +94,9 @@ def main(
             f"| {server} - logged in as deployment #{sapp.deployment_id}", err=True,
         )
         if policy:
-            click.echo(f"| using policy {policy}")
+            click.echo(f"| policy - using {policy}")
+        else:
+            click.echo(f"| policy - unknown")
     else:
         click.echo(f"| {server} - not logged in", err=True)
 

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -4,6 +4,7 @@ import tempfile
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
+from typing import cast
 from typing import List
 from typing import Optional
 
@@ -74,7 +75,7 @@ class Sapp:
                 ignore_patterns=glom(body, T["scan"]["meta"].get("ignored_files", [])),
             )
             debug_echo(f"=== Our scan object is: {self.scan!r}")
-            return str(glom(body, T["policy"])) if "policy" in body else None
+            return cast(Optional[str], glom(body, T["policy"], default=None))
 
     def fetch_rules_text(self) -> str:
         """Get a YAML string with the configured semgrep rules in it."""

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -48,10 +48,10 @@ class Sapp:
         self.session = requests.Session()
         self.session.headers["Authorization"] = f"Bearer {self.token}"
 
-    def report_start(self, meta: GitMeta) -> None:
+    def report_start(self, meta: GitMeta) -> Optional[str]:
         if not self.is_configured:
             debug_echo("=== no semgrep app config, skipping report_start")
-            return
+            return None
         debug_echo(f"=== reporting start to semgrep app at {self.url}")
 
         response = self.session.post(
@@ -74,6 +74,7 @@ class Sapp:
                 ignore_patterns=glom(body, T["scan"]["meta"].get("ignored_files", [])),
             )
             debug_echo(f"=== Our scan object is: {self.scan!r}")
+            return str(glom(body, T["policy"]))
 
     def fetch_rules_text(self) -> str:
         """Get a YAML string with the configured semgrep rules in it."""

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -74,7 +74,7 @@ class Sapp:
                 ignore_patterns=glom(body, T["scan"]["meta"].get("ignored_files", [])),
             )
             debug_echo(f"=== Our scan object is: {self.scan!r}")
-            return str(glom(body, T["policy"]))
+            return str(glom(body, T["policy"])) if "policy" in body else None
 
     def fetch_rules_text(self) -> str:
         """Get a YAML string with the configured semgrep rules in it."""


### PR DESCRIPTION
When debugging, it is useful to know which environment variables have been properly detected by the system.

Policy printing will work once https://github.com/returntocorp/semgrep-app/pull/1126 is deployed

Closes https://github.com/returntocorp/semgrep-app/issues/1107