### PR TITLE
Fix crash when a newly created file yields issues

### DIFF
--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -159,9 +159,14 @@ def invoke_semgrep(
         )
     else:
         with targets.baseline_paths() as paths:
-            if paths:
-                paths_with_findings = {finding.path for finding in findings.current}
-                paths_to_check = set(str(path) for path in paths) & paths_with_findings
+            paths_with_findings = {finding.path for finding in findings.current}
+            paths_to_check = set(str(path) for path in paths) & paths_with_findings
+            if not paths_to_check:
+                click.echo(
+                    "=== not looking at pre-existing issues since all files with current issues are newly created",
+                    err=True,
+                )
+            else:
                 click.echo(
                     "=== looking for pre-existing issues in "
                     + unit_len(paths_to_check, "file"),

--- a/src/semgrep_agent/targets.py
+++ b/src/semgrep_agent/targets.py
@@ -278,9 +278,12 @@ class TargetFileManager:
         """
         Prepare file system for baseline scan, and return the paths to be analyzed.
 
-        Returned list of paths are all abolute paths and include all files that are
+        Returned list of paths are all relative paths and include all files that are
+            - already in the baseline commit, i.e. not created later
             - not ignored based on .semgrepignore rules
             - in any path include filters specified.
+
+        Returned list is empty if a baseline commit is inaccessible.
 
         :return: A list of paths
         :raises ActionFailure: If git cannot detect a HEAD commit or unmerged files exist
@@ -303,7 +306,7 @@ class TargetFileManager:
         """
         Prepare file system for current scan, and return the paths to be analyzed.
 
-        Returned list of paths are all abolute paths and include all files that are
+        Returned list of paths are all relative paths and include all files that are
             - not ignored based on .semgrepignore rules
             - in any path include filters specified.
 

--- a/src/semgrep_agent/targets.py
+++ b/src/semgrep_agent/targets.py
@@ -285,11 +285,18 @@ class TargetFileManager:
         :return: A list of paths
         :raises ActionFailure: If git cannot detect a HEAD commit or unmerged files exist
         """
-        if self._base_commit is None:
+        repo = get_git_repo()
+
+        if not repo or self._base_commit is None:
             yield []
         else:
             with self._baseline_context():
-                yield self._target_paths
+                yield [
+                    relative_path
+                    for relative_path in self._target_paths
+                    if self._fname_to_path(repo, str(relative_path))
+                    not in self._status.added
+                ]
 
     @contextmanager
     def current_paths(self) -> Iterator[List[Path]]:


### PR DESCRIPTION
The target manager used to yield all paths as paths to check on the
baseline commit. This used to be okay since when these are passed to
semgrep with --include, they are silently ignored. But since we switched
to explicit targeting, passing non-existent paths causes a crash.