### PR TITLE
allow manual override of repo name

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -36,8 +36,11 @@ class CliObj:
 def get_event_type() -> str:
     if "GITHUB_ACTIONS" in os.environ:
         return os.environ["GITHUB_EVENT_NAME"]
-
     return "push"
+
+
+def get_aligned_command(title: str, subtext: str) -> str:
+    return f"| {title.ljust(17)} - {subtext}"
 
 
 @click.command()
@@ -65,23 +68,24 @@ def main(
 ) -> NoReturn:
     click.echo("=== detecting environment", err=True)
     click.echo(
-        f"| versions    - "
-        f"semgrep {sh.semgrep(version=True).strip()} on "
-        f"{sh.python(version=True).strip()}",
+        get_aligned_command(
+            "versions",
+            f"semgrep {sh.semgrep(version=True).strip()} on {sh.python(version=True).strip()}",
+        ),
         err=True,
     )
 
     # Get Metadata
-    # server = os.getenv("INPUT_PUBLISHURL") or "https://semgrep.dev"
     Meta = detect_meta_environment()
     meta_kwargs = {}
     if baseline_ref:
         meta_kwargs["cli_baseline_ref"] = baseline_ref
     meta = Meta(config, **meta_kwargs)
     click.echo(
-        f"| environment - "
-        f"running in {meta.environment}, "
-        f"triggering event is '{meta.event_name}'",
+        get_aligned_command(
+            "environment",
+            f"running in environment {meta.environment}, triggering event is '{meta.event_name}'",
+        ),
         err=True,
     )
 
@@ -90,22 +94,17 @@ def main(
     maybe_print_debug_info(meta)
     policy = sapp.report_start(meta)
     if sapp.is_configured:
-        if publish_url == "https://semgrep.dev":
-            click.echo(
-                f"| Semgrep Community - logged in as deployment #{sapp.deployment_id}",
-                err=True,
-            )
-        else:
-            click.echo(
-                f"| Semgrep Community - logged in to {publish_url} as deployment #{sapp.deployment_id}",
-                err=True,
-            )
-        if policy:
-            click.echo(f"| policy - using {policy}")
-        else:
-            click.echo(f"| policy - unknown")
+        server = "" if publish_url == "https://semgrep.dev" else f"to {publish_url}"
+        click.echo(
+            get_aligned_command(
+                "manage", f"logged in {server} as deployment #{sapp.deployment_id}"
+            ),
+            err=True,
+        )
+        policy_info = f"using {policy}" if policy else "unknown"
+        click.echo(get_aligned_command("policy", policy_info))
     else:
-        click.echo(f"| Semgrep Community - not logged in", err=True)
+        click.echo(get_aligned_command("manage", f"not logged in"), err=True)
 
     for env_var in [
         "SEMGREP_REPO_URL",
@@ -113,9 +112,10 @@ def main(
         "SEMGREP_BRANCH",
         "SEMGREP_PR_ID",
         "SEMGREP_PR_TITLE",
+        "SEMGREP_REPO_NAME",
     ]:
         if os.getenv(env_var):
-            click.echo(f"| {env_var} - {os.getenv(env_var)}")
+            click.echo(get_aligned_command(env_var, str(os.getenv(env_var))))
 
     # Setup Config
     click.echo("=== setting up agent configuration", err=True)

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -107,12 +107,12 @@ def main(
         click.echo(get_aligned_command("manage", f"not logged in"), err=True)
 
     for env_var in [
+        "SEMGREP_REPO_NAME",
         "SEMGREP_REPO_URL",
         "SEMGREP_JOB_URL",
         "SEMGREP_BRANCH",
         "SEMGREP_PR_ID",
         "SEMGREP_PR_TITLE",
-        "SEMGREP_REPO_NAME",
     ]:
         if os.getenv(env_var):
             click.echo(get_aligned_command(env_var, str(os.getenv(env_var))))

--- a/src/semgrep_agent/meta.py
+++ b/src/semgrep_agent/meta.py
@@ -43,7 +43,9 @@ class GitMeta:
     def repo_name(self) -> str:
         if not self.repo.head.is_valid():
             raise RuntimeError("Semgrep action cannot run on repository with no HEAD")
-        return str(os.path.basename(self.repo.working_tree_dir))
+        return os.getenv("SEMGREP_REPO_NAME") or str(
+            os.path.basename(self.repo.working_tree_dir)
+        )
 
     @cachedproperty
     def repo_url(self) -> Optional[str]:


### PR DESCRIPTION
using optional environment variable: SEMGREP_REPO_NAME
adds vertical alignment to printed statements

fixes https://github.com/returntocorp/semgrep-app/issues/1105
