### PR TITLE
Allow untracked paths to be present

### DIFF
--- a/stubs/boltons/iterutils.pyi
+++ b/stubs/boltons/iterutils.pyi
@@ -1,6 +1,17 @@
-from typing import Any, Iterable, TypeVar
+from typing import Any, Callable, Dict, Hashable, Iterable, List, Optional, TypeVar
 
 Item = TypeVar("Item")
 Items = Iterable[Item]
 
 def chunked_iter(src: Items, size: int, **kw: Any) -> Iterable[Items]: ...
+
+BucketKey_co = TypeVar("BucketKey_co", bound=Hashable, covariant=True)
+BucketItem_co = TypeVar("BucketItem_co", covariant=True)
+SourceItem_co = TypeVar("SourceItem_co", covariant=True)
+
+def bucketize(
+    src: Iterable[SourceItem_co],
+    key: Callable[[SourceItem_co], BucketKey_co] = ...,
+    value_transform: Optional[Callable[[SourceItem_co], BucketItem_co]] = None,
+    key_filter: Optional[Callable[[BucketKey_co], bool]] = None,
+) -> Dict[BucketKey_co, List[BucketItem_co]]: ...


### PR DESCRIPTION
But we still need to worry about the edge case where someone removes a path since the baseline, and now has the same path as untracked. That should not be allowed.

Changes were tested manually with the following commands:

    git rm --cached README.md
    echo "5 == 5" > bad.py
    git add bad.py
    git commit -m "preparation commit"
    poetry run python -m semgrep_agent --config p/python --baseline-ref HEAD~1
    // should see a complaint that README changed and is untracked

    rm README.md
    touch new-file
    poetry run python -m semgrep_agent --config p/python --baseline-ref HEAD~1
    // should see successful scan with 5 == 5

    echo "hiii" > LICENSE
    poetry run python -m semgrep_agent --config p/python --baseline-ref HEAD~1
    // should see a complaint that there are changes to tracked files

    git add LICENSE
    poetry run python -m semgrep_agent --config p/python --baseline-ref HEAD~1
    // should see a complaint that there are changes to tracked files