### PR TITLE
Allow passing any arg with --semgrep-opts

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -61,6 +61,7 @@ def get_aligned_command(title: str, subtext: str) -> str:
 @click.option(
     "--gitlab-json", "gitlab_output", envvar="SEMGREP_GITLAB_JSON", is_flag=True
 )
+@click.option("--semgrep-opts", type=str)
 def main(
     config: str,
     baseline_ref: str,
@@ -69,6 +70,7 @@ def main(
     publish_deployment: int,
     json_output: bool,
     gitlab_output: bool,
+    semgrep_opts: str,
 ) -> NoReturn:
     click.echo("=== detecting environment", err=True)
     click.echo(
@@ -175,6 +177,7 @@ def main(
         meta.head_ref,
         semgrep.get_semgrepignore(sapp.scan.ignore_patterns),
         sapp.is_configured,
+        semgrep_opts=semgrep_opts,
     )
     new_findings = results.findings.new
 

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -57,11 +57,11 @@ def get_aligned_command(title: str, subtext: str) -> str:
 )
 @click.option("--publish-token", envvar="INPUT_PUBLISHTOKEN", type=str)
 @click.option("--publish-deployment", envvar="INPUT_PUBLISHDEPLOYMENT", type=int)
-@click.option("--json", "json_output", hidden=True, is_flag=True)
 @click.option(
     "--gitlab-json", "gitlab_output", envvar="SEMGREP_GITLAB_JSON", is_flag=True
 )
-@click.option("--semgrep-opts", type=str)
+@click.option("--json", "json_output", hidden=True, is_flag=True)
+@click.option("--semgrep-opts", hidden=True, type=str)
 def main(
     config: str,
     baseline_ref: str,

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -8,6 +8,7 @@ import urllib.parse
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
+from json.decoder import JSONDecodeError
 from pathlib import Path
 from textwrap import dedent
 from textwrap import indent
@@ -45,6 +46,16 @@ semgrep = sh.semgrep.bake(_ok_code={0, 1}, _tty_out=False, _env=ua_environ)
 # a typical old system has 128 * 1024 as their max command length
 # we assume an average ~250 characters for a path in the worst case
 PATHS_CHUNK_SIZE = 500
+
+
+class SemgrepCommandFailure(Exception):
+    """This imitates ``sh.ErrorReturnCode``, but is raised when Semgrep fails with exit code 0."""
+
+    def __init__(self, command: sh.RunningCommand):
+        self.stdout = command.stdout
+        self.stderr = command.stderr
+        self.full_cmd = b" ".join(command.cmd).decode()
+        self.exit_code = command.exit_code
 
 
 def resolve_config_shorthand(config: str) -> str:
@@ -183,6 +194,7 @@ def invoke_semgrep(
 
         config_args = ["--config", config_specifier]
         rewrite_args = ["--no-rewrite-rule-ids"] if uses_managed_policy else []
+        user_provided_args = shlex.split(semgrep_opts)  # incompatible with Windows
 
         debug_echo("=== seeing if there are any findings")
         findings = FindingSets()
@@ -198,10 +210,15 @@ def invoke_semgrep(
                     "--json",
                     *rewrite_args,
                     *config_args,
+                    *user_provided_args,
                 ]
                 for path in chunk:
                     args.append(path)
-                semgrep_results = json.loads(str(semgrep(*args)))["results"]
+                semgrep_command = semgrep(*args)
+                try:
+                    semgrep_results = json.loads(str(semgrep_command))["results"]
+                except (JSONDecodeError, KeyError):
+                    raise SemgrepCommandFailure(semgrep_command)
                 findings.current.update_findings(
                     Finding.from_semgrep_result(result, committed_datetime)
                     for result in semgrep_results
@@ -246,11 +263,15 @@ def invoke_semgrep(
                         "--json",
                         *rewrite_args,
                         *config_args,
-                        *shlex.split(semgrep_opts),  # incompatible with Windows
+                        *user_provided_args,
                     ]
                     for path in chunk:
                         args.append(path)
-                    semgrep_results = json.loads(str(semgrep(*args)))["results"]
+                    semgrep_command = semgrep(*args)
+                    try:
+                        semgrep_results = json.loads(str(semgrep_command))["results"]
+                    except (JSONDecodeError, KeyError):
+                        raise SemgrepCommandFailure(semgrep_command)
                     findings.baseline.update_findings(
                         Finding.from_semgrep_result(result, committed_datetime)
                         for result in semgrep_results
@@ -295,7 +316,19 @@ def scan(
             uses_managed_policy,
             semgrep_opts=semgrep_opts,
         )
-    except sh.ErrorReturnCode as error:
+    except (sh.ErrorReturnCode, SemgrepCommandFailure) as error:
+        if not semgrep_opts:
+            next_steps = (
+                "This is an internal error, please file an issue at "
+                "https://github.com/returntocorp/semgrep-action/issues/new/choose "
+                "and include any log output from above."
+            )
+        else:
+            next_steps = (
+                f"You've passed these custom semgrep options: '{semgrep_opts}'. "
+                "Custom options can easily break the internals of semgrep-agent, "
+                "so please reproduce this error without them before opening an issue."
+            )
         message = f"""
         === failed command's STDOUT:
 
@@ -307,8 +340,7 @@ def scan(
 
         === [ERROR] `{error.full_cmd}` failed with exit code {error.exit_code}
 
-        This is an internal error, please file an issue at https://github.com/returntocorp/semgrep-action/issues/new/choose
-        and include any log output from above.
+        {next_steps}
         """
         message = dedent(message).strip()
         click.echo("", err=True)

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -1,6 +1,7 @@
 import io
 import json
 import os
+import shlex
 import sys
 import time
 import urllib.parse
@@ -166,6 +167,8 @@ def invoke_semgrep(
     head_ref: Optional[str],
     semgrep_ignore: TextIO,
     uses_managed_policy: bool,
+    *,
+    semgrep_opts: str,
 ) -> FindingSets:
     debug_echo("=== adding semgrep configuration")
 
@@ -243,6 +246,7 @@ def invoke_semgrep(
                         "--json",
                         *rewrite_args,
                         *config_args,
+                        *shlex.split(semgrep_opts),  # incompatible with Windows
                     ]
                     for path in chunk:
                         args.append(path)
@@ -277,6 +281,8 @@ def scan(
     head_ref: Optional[str],
     semgrep_ignore: TextIO,
     uses_managed_policy: bool,
+    *,
+    semgrep_opts: str,
 ) -> Results:
     before = time.time()
     try:
@@ -287,6 +293,7 @@ def scan(
             head_ref,
             semgrep_ignore,
             uses_managed_policy,
+            semgrep_opts=semgrep_opts,
         )
     except sh.ErrorReturnCode as error:
         message = f"""

--- a/stubs/sh/__init__.pyi
+++ b/stubs/sh/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Union
+from typing import Any, Callable, Sequence, Union
 
 class ErrorReturnCode(Exception):
     @property
@@ -29,6 +29,7 @@ class Command(GitSubcommandsMixin):
     def bake(self, *args: Any, **kwargs: Any) -> Command: ...
 
 class RunningCommand(str, GitSubcommandsMixin):
+    cmd: Sequence[bytes]
     @property
     def stdout(self) -> bytes: ...
     @property


### PR DESCRIPTION
Tested by running:

```
python -m semgrep_agent --config p/r2c --baseline-ref HEAD~3 --semgrep-opts '--max-lines-per-finding 45 -j "2" --timeout 90'
```