### PR TITLE
Revert "Allow passing any arg with --semgrep-opts (#147)"

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -57,11 +57,10 @@ def get_aligned_command(title: str, subtext: str) -> str:
 )
 @click.option("--publish-token", envvar="INPUT_PUBLISHTOKEN", type=str)
 @click.option("--publish-deployment", envvar="INPUT_PUBLISHDEPLOYMENT", type=int)
+@click.option("--json", "json_output", hidden=True, is_flag=True)
 @click.option(
     "--gitlab-json", "gitlab_output", envvar="SEMGREP_GITLAB_JSON", is_flag=True
 )
-@click.option("--json", "json_output", hidden=True, is_flag=True)
-@click.option("--semgrep-opts", hidden=True, type=str)
 def main(
     config: str,
     baseline_ref: str,
@@ -70,7 +69,6 @@ def main(
     publish_deployment: int,
     json_output: bool,
     gitlab_output: bool,
-    semgrep_opts: str,
 ) -> NoReturn:
     click.echo("=== detecting environment", err=True)
     click.echo(
@@ -177,7 +175,6 @@ def main(
         meta.head_ref,
         semgrep.get_semgrepignore(sapp.scan.ignore_patterns),
         sapp.is_configured,
-        semgrep_opts=semgrep_opts,
     )
     new_findings = results.findings.new
 

--- a/stubs/sh/__init__.pyi
+++ b/stubs/sh/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Sequence, Union
+from typing import Any, Callable, Union
 
 class ErrorReturnCode(Exception):
     @property
@@ -29,7 +29,6 @@ class Command(GitSubcommandsMixin):
     def bake(self, *args: Any, **kwargs: Any) -> Command: ...
 
 class RunningCommand(str, GitSubcommandsMixin):
-    cmd: Sequence[bytes]
     @property
     def stdout(self) -> bytes: ...
     @property


### PR DESCRIPTION
This reverts commit 550275f02a71b675773d108f2f08c98658ce87cf.

(customer reported scans suddenly timing out after this commit)

I already pushed v1 tag back to before this commit and confirmed that this fixed the issue: https://r2c-community.slack.com/archives/G01CKAQDRA4/p1610212521012200