### PR TITLE
fix: remove pipx caching for github action to fix CI failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           path: |
             .pipx/venvs/semgrep
             .pipx_bin/semgrep*
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pipx-semgrep-${{ steps.setup-package-managers.outputs.installed-semgrep-version }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pipx-semgrep-somekey${{ steps.setup-package-managers.outputs.installed-semgrep-version }}
 
       - id: reuse-poetry-virtualenv
         name: Reuse poetry's virtualenv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           path: |
             .pipx/venvs/semgrep
             .pipx_bin/semgrep*
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pipx-semgrep-v${{ steps.setup-package-managers.outputs.installed-semgrep-version }}
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pipx-semgrep-${{ steps.setup-package-managers.outputs.installed-semgrep-version }}
 
       - id: reuse-poetry-virtualenv
         name: Reuse poetry's virtualenv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,15 +31,6 @@ jobs:
           poetry config virtualenvs.in-project true
           echo "::set-output name=installed-semgrep-version::$(sed --quiet --regexp-extended 's/.+INSTALLED_SEMGREP_VERSION=(.+)/\1/p' Dockerfile)"
 
-      - id: reuse-pipx-semgrep-virtualenv
-        name: Reuse pipx semgrep virtualenv
-        uses: actions/cache@v2
-        with:
-          path: |
-            .pipx/venvs/semgrep
-            .pipx_bin/semgrep*
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pipx-semgrep-somekey${{ steps.setup-package-managers.outputs.installed-semgrep-version }}
-
       - id: reuse-poetry-virtualenv
         name: Reuse poetry's virtualenv
         uses: actions/cache@v2
@@ -50,7 +41,6 @@ jobs:
       # install semgrep first so that errors are more obvious if agent dependencies conflict
       - name: Install semgrep
         run: pipx install semgrep==${{ steps.setup-package-managers.outputs.installed-semgrep-version }}
-        if: steps.reuse-pipx-semgrep-virtualenv.outputs.cache-hit != 'true'
 
       - name: Install dependencies
         run: poetry install --no-root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-FROM returntocorp/semgrep:0.36.0@sha256:8d47e7ca46b0e06a5f2d3a3c945df3ca068f19b992b44f6d750e67b213b802a8 AS semgrep
 FROM python:3.7-alpine
 
 WORKDIR /app
@@ -7,13 +6,11 @@ COPY pyproject.toml ./
 
 ENV INSTALLED_SEMGREP_VERSION=0.36.0
 
-COPY --from=semgrep /usr/local/bin/semgrep-core /tmp/semgrep-core
-
 RUN apk add --no-cache --virtual=.build-deps build-base libffi-dev openssl-dev &&\
     apk add --no-cache --virtual=.run-deps bash git less libffi openssl &&\
     pip install --no-cache-dir poetry==1.0.10 &&\
     pip install --no-cache-dir pipx &&\
-    PRECOMPILED_LOCATION=/tmp/semgrep-core pipx install semgrep==${INSTALLED_SEMGREP_VERSION} &&\
+    pipx install semgrep==${INSTALLED_SEMGREP_VERSION} &&\
     poetry config virtualenvs.create false &&\
     # Don't install dev dependencies or semgrep-agent
     poetry install --no-dev --no-root &&\


### PR DESCRIPTION
With changes to setup.py in 0.36.0 looks like pipx caching we do in the github action is not correctly caching semgrep. Removing for now.