### PR TITLE
Use semgrep -o to ensure always parsable json

### DIFF
--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -229,12 +229,19 @@ def invoke_semgrep(semgrep_args: List[str], targets: List[str]) -> Dict[str, Lis
     for chunk in chunked_iter(targets, PATHS_CHUNK_SIZE):
         with tempfile.NamedTemporaryFile("w") as output_json_file:
             args = semgrep_args.copy()
-            args.extend(["-o", output_json_file.name])
+            args.extend(
+                [
+                    "-o",
+                    output_json_file.name,  # nosem: python.lang.correctness.tempfile.flush.tempfile-without-flush
+                ]
+            )
             for c in chunk:
                 args.append(c)
 
             _ = semgrep_exec(*(args))
-            with open(output_json_file.name) as f:
+            with open(
+                output_json_file.name  # nosem: python.lang.correctness.tempfile.flush.tempfile-without-flush
+            ) as f:
                 parsed_output = json.load(f)
 
             output["results"].extend(parsed_output["results"])

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -2,6 +2,7 @@ import io
 import json
 import os
 import sys
+import tempfile
 import time
 import urllib.parse
 from dataclasses import dataclass
@@ -36,7 +37,7 @@ from semgrep_agent.utils import exit_with_sh_error
 from semgrep_agent.utils import fix_head_for_github
 
 ua_environ = {"SEMGREP_USER_AGENT_APPEND": "(Agent)", **os.environ}
-semgrep = sh.semgrep.bake(_ok_code={0, 1}, _tty_out=False, _env=ua_environ)
+semgrep_exec = sh.semgrep.bake(_ok_code={0, 1}, _tty_out=False, _env=ua_environ)
 
 # a typical old system has 128 * 1024 as their max command length
 # we assume an average ~250 characters for a path in the worst case
@@ -107,7 +108,7 @@ def rewrite_sarif_file(sarif_path: Path) -> None:
         json.dump(sarif_results, sarif_file, indent=2, sort_keys=True)
 
 
-def invoke_semgrep(
+def get_findings(
     config_specifier: str,
     committed_datetime: Optional[datetime],
     base_commit_ref: Optional[str],
@@ -136,34 +137,33 @@ def invoke_semgrep(
             click.echo(
                 "=== looking for current issues in " + unit_len(paths, "file"), err=True
             )
-            for chunk in chunked_iter(paths, PATHS_CHUNK_SIZE):
-                args = [
-                    "--skip-unknown-extensions",
-                    "--disable-nosem",
-                    "--json",
-                    *rewrite_args,
-                    *config_args,
-                ]
-                for path in chunk:
-                    args.append(path)
-                semgrep_results = json.loads(str(semgrep(*args)))["results"]
-                findings.current.update_findings(
-                    Finding.from_semgrep_result(result, committed_datetime)
-                    for result in semgrep_results
-                    if not result["extra"].get("is_ignored")
-                )
-                findings.ignored.update_findings(
-                    Finding.from_semgrep_result(result, committed_datetime)
-                    for result in semgrep_results
-                    if result["extra"].get("is_ignored")
-                )
-                click.echo(
-                    f"| {unit_len(findings.current, 'current issue')} found", err=True
-                )
-                click.echo(
-                    f"| {unit_len(findings.ignored, 'ignored issue')} found",
-                    err=True,
-                )
+
+            args = [
+                "--skip-unknown-extensions",
+                "--disable-nosem",
+                "--json",
+                *rewrite_args,
+                *config_args,
+            ]
+            semgrep_results = invoke_semgrep(args, [str(p) for p in paths])["results"]
+
+            findings.current.update_findings(
+                Finding.from_semgrep_result(result, committed_datetime)
+                for result in semgrep_results
+                if not result["extra"].get("is_ignored")
+            )
+            findings.ignored.update_findings(
+                Finding.from_semgrep_result(result, committed_datetime)
+                for result in semgrep_results
+                if result["extra"].get("is_ignored")
+            )
+            click.echo(
+                f"| {unit_len(findings.current, 'current issue')} found", err=True
+            )
+            click.echo(
+                f"| {unit_len(findings.ignored, 'ignored issue')} found",
+                err=True,
+            )
 
     if not findings.current:
         click.echo(
@@ -173,7 +173,9 @@ def invoke_semgrep(
     else:
         with targets.baseline_paths() as paths:
             paths_with_findings = {finding.path for finding in findings.current}
-            paths_to_check = set(str(path) for path in paths) & paths_with_findings
+            paths_to_check = list(
+                set(str(path) for path in paths) & paths_with_findings
+            )
             if not paths_to_check:
                 click.echo(
                     "=== not looking at pre-existing issues since all files with current issues are newly created",
@@ -185,20 +187,18 @@ def invoke_semgrep(
                     + unit_len(paths_to_check, "file"),
                     err=True,
                 )
-                for chunk in chunked_iter(paths_to_check, PATHS_CHUNK_SIZE):
-                    args = [
-                        "--skip-unknown-extensions",
-                        "--json",
-                        *rewrite_args,
-                        *config_args,
-                    ]
-                    for path in chunk:
-                        args.append(path)
-                    semgrep_results = json.loads(str(semgrep(*args)))["results"]
-                    findings.baseline.update_findings(
-                        Finding.from_semgrep_result(result, committed_datetime)
-                        for result in semgrep_results
-                    )
+
+                args = [
+                    "--skip-unknown-extensions",
+                    "--json",
+                    *rewrite_args,
+                    *config_args,
+                ]
+                semgrep_results = invoke_semgrep(args, paths_to_check)["results"]
+                findings.baseline.update_findings(
+                    Finding.from_semgrep_result(result, committed_datetime)
+                    for result in semgrep_results
+                )
                 click.echo(
                     f"| {unit_len(findings.baseline, 'pre-existing issue')} found",
                     err=True,
@@ -211,11 +211,36 @@ def invoke_semgrep(
         with targets.current_paths() as paths, sarif_path.open("w") as sarif_file:
             args = ["--sarif", *rewrite_args, *config_args]
             for path in paths:
-                args.extend(["--include", path])
-            semgrep(*args, _out=sarif_file)
+                args.extend(["--include", str(path)])
+            semgrep_exec(*args, _out=sarif_file)
         rewrite_sarif_file(sarif_path)
 
     return findings
+
+
+def invoke_semgrep(semgrep_args: List[str], targets: List[str]) -> Dict[str, List[Any]]:
+    """
+    Call semgrep passing in semgrep_args + targets as the arguments
+
+    Returns json output of semgrep as dict object
+    """
+    output: Dict[str, List[Any]] = {"results": [], "errors": []}
+
+    for chunk in chunked_iter(targets, PATHS_CHUNK_SIZE):
+        with tempfile.NamedTemporaryFile("w") as output_json_file:
+            args = semgrep_args.copy()
+            args.extend(["-o", output_json_file.name])
+            for c in chunk:
+                args.append(c)
+
+            _ = semgrep_exec(*(args))
+            with open(output_json_file.name) as f:
+                parsed_output = json.load(f)
+
+            output["results"].extend(parsed_output["results"])
+            output["errors"].extend(parsed_output["errors"])
+
+    return output
 
 
 def scan(
@@ -228,7 +253,7 @@ def scan(
 ) -> Results:
     before = time.time()
     try:
-        findings = invoke_semgrep(
+        findings = get_findings(
             config_specifier,
             committed_datetime,
             base_commit_ref,

--- a/tests/acceptance/semgrep-rules-repo/local-config-full-scan.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-full-scan.err
@@ -10,9 +10,5 @@ Note that no baseline-ref was passed and detected environment is not Github or G
 === looking for current issues in 1473 files
 | 2 current issues found
 | No ignored issues found
-| 2 current issues found
-| No ignored issues found
-| 2 current issues found
-| No ignored issues found
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status


### PR DESCRIPTION
Semgrep output can sometimes be polluted causing json parsing to fail
Use -o option and parse the file so json parsing will never fail.