### PR TITLE
Add retry logic to cloud app requests

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -38,3 +38,6 @@ warn_return_any = True
 
 [mypy-git.*]
 ignore_missing_imports = True
+
+[mypy-urllib3.*]
+ignore_missing_imports = True


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep-app/issues/1976.

This will retry to following cloud app requests:

- POST `/scan`
- GET `/rules.yaml`
- POST `/error`
- POST `/findings`
- POST `/ignores`
- POST `/complete`

I believe, typically, you do not want to retry POST requests because they're not idempotent. I think we're okay here for the following reasons: 1.) the latter 4 POST requests above will fail if the scan has already completed, 2.) the first POST request shouldn't have succeeded and been created if we're retrying. That is, if the original request failed, then we shouldn't have to worry about double scanning. There may be some race condition concerns here, but I think this is a good first pass.