### PR TITLE
Catch other exceptions besides ActionFailure and SemgrepError

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import sys
 from dataclasses import dataclass
@@ -118,6 +119,7 @@ def main(
     gitlab_output: bool,
     audit_on: Sequence[str],
 ) -> NoReturn:
+
     click.echo(
         get_aligned_command(
             "versions",
@@ -224,6 +226,11 @@ def main(
 
     committed_datetime = meta.commit.committed_datetime if meta.commit else None
 
+    # Fail-open is only used to catch errors after this point because the scan must
+    # exist in order to post to /api/agent/scan/{self.scan.id}/error right now. At
+    # a later date, we may want to catch errors above this point and configure
+    # fail-open at an org-wide level, with opportunity to override at a more granular level
+    # Then we could catch all errors in main() for fail-open
     try:
         results = semgrep.scan(
             config,
@@ -238,6 +245,12 @@ def main(
         _handle_error(error.stderr, error.exit_code, sapp)
     except ActionFailure as error:
         click.secho(str(error), err=True, fg="red")
+        _handle_error(str(error), 2, sapp)
+    except Exception as error:
+        # Handles all other errors like FileNotFound, EOF, etc.
+        # https://docs.python.org/3.9/library/exceptions.html#exception-hierarchy
+        click.secho(f"An unexpected error occurred", err=True, fg="red")
+        logging.exception(error)
         _handle_error(str(error), 2, sapp)
 
     new_findings = results.findings.new
@@ -293,7 +306,7 @@ def _handle_error(stderr: str, exit_code: int, sapp: Sapp) -> None:
         new_exit_code = sapp.report_failure(stderr, exit_code)
         if new_exit_code == 0:
             click.echo(
-                f"Semgrep returned an error (return code {exit_code}). However, this project's policy on {sapp.url} is configured to pass the build on Semgrep errors. This CI job will exit with a successful return code 0.",
+                f"Semgrep returned an error (return code {exit_code}). However, this project on {sapp.url} is configured to pass the build on Semgrep errors (fail open). Exiting with a successful return code 0.",
                 err=True,
             )
         sys.exit(new_exit_code)


### PR DESCRIPTION
This looks weird (revert revert) because I accidentally pushed directly to develop but could not force-push to undo that accidental push.

So, I ended up reverting develop and reverting that revert in this pull request to get some eyes 😆 

I have tested that this does in fact catch a FileNotFoundError (original bug reported by user) and still gives enough information in the error message to be helpful to us when debugging (printing the error just gives None)

<img width="970" alt="Screen Shot 2021-03-29 at 5 20 45 PM" src="https://user-images.githubusercontent.com/25408780/112901714-f46b4980-9099-11eb-97f8-984ea31996fd.png">

@dlukeomalley after working on this today, I think that we should make fail_open an org-wide setting, so that we can catch _all_ semgrep-action errors and return 0, not just those that occur between when the scan is created and when it is finished (this PR).

Making fail-open org-wide requires some significant semgrep-app modifications, so I decided to just fix this first to downscope.
