### PR TITLE
Fail open covers everything other than reading environment variables

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -124,6 +124,13 @@ def main(
     audit_on: Sequence[str],
     timeout: int,
 ) -> NoReturn:
+    click.echo(
+        get_aligned_command(
+            "versions",
+            f"semgrep {sh.semgrep(version=True).strip()} on {sh.python(version=True).strip()}",
+        ),
+        err=True,
+    )
     # Get metadata from environment variables
     meta = generate_meta_from_environment(baseline_ref)
     sapp = Sapp(url=publish_url, token=publish_token, deployment_id=publish_deployment)
@@ -166,13 +173,6 @@ def protected_main(
     sapp: Sapp,
     meta: GitMeta,
 ) -> NoReturn:
-    click.echo(
-        get_aligned_command(
-            "versions",
-            f"semgrep {sh.semgrep(version=True).strip()} on {sh.python(version=True).strip()}",
-        ),
-        err=True,
-    )
     meta.initialize_repo()
     maybe_print_debug_info(meta)
     click.echo(

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -59,6 +59,16 @@ class Sapp:
         self.session.mount("https://", RETRYING_ADAPTER)
         self.session.headers["Authorization"] = f"Bearer {self.token}"
 
+    def fail_open_exit_code(self, meta: GitMeta, exit_code: int) -> int:
+        response = self.session.get(
+            f"{self.url}/api/agent/deployment/{self.deployment_id}/repos/{meta.repo_name}",
+            json={},
+            timeout=30,
+        )
+        repo_data = response.json()
+        fail_open = repo_data.get("repo").get("fail_open")
+        return 0 if fail_open else exit_code
+
     def report_start(self, meta: GitMeta) -> str:
         """
         Get scan id and file ignores


### PR DESCRIPTION
Previously, fail-open was only used by semgrep_app to determine the exit code returned to semgrep_action. This only covered errors between when the scan was created and when it was finished, leaving plenty of semgrep_action code unprotected by the fail_open flag. I realized this when investigating: https://github.com/returntocorp/semgrep-app/issues/1922

Now, fail-open covers all errors in semgrep-action after the GitMeta and Saas objects are initialized. This will help protect customers in the future from receiving 4XX errors even though fail-open was enabled. 

This does _not_ do anything to cover 5XX errors, as fail-open is still configured on the app and semgrep-action needs to reach the app to determine whether or not fail-open is True.

- [x] Tested by raising a FileNotFoundError at the start of protected_main with and without fail_open set to True