### PR TITLE
Clearly acknowledge in printouts that CAI is running

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -209,7 +209,7 @@ def protected_main(
         config = semgrep.resolve_config_shorthand(config)
         click.echo(f"| using semgrep rules from {config}", err=True)
     elif sapp.is_configured:
-        local_config_path, num_rules = sapp.download_rules()
+        local_config_path, num_rules, cai_rules = sapp.download_rules()
         if num_rules == 0:
             message = """
             == [ERROR] This policy will not run any rules
@@ -228,6 +228,8 @@ def protected_main(
         click.echo(
             f"| using {num_rules} semgrep rules configured on the web UI", err=True
         )
+        if cai_rules:
+            click.echo(f"| using {cai_rules} code asset inventory rules")
     elif Path(".semgrep.yml").is_file():
         click.echo("| using semgrep rules from the committed .semgrep.yml", err=True)
         config = ".semgrep.yml"


### PR DESCRIPTION
do not lump CAI rules with others when telling user what is running - it removes the user's ability to debug what their policies contain

Fixes https://github.com/returntocorp/semgrep-app/issues/2280

<img width="971" alt="Screen Shot 2021-04-21 at 5 07 38 PM" src="https://user-images.githubusercontent.com/25408780/115637011-14baac80-a2c4-11eb-853b-02be0aa13a68.png">
