### PR TITLE
catch invalid git repo error

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -11,6 +11,7 @@ from typing import Sequence
 import click
 import sh
 from boltons.strutils import unit_len
+from git import InvalidGitRepositoryError
 
 from semgrep_agent import formatter
 from semgrep_agent import semgrep
@@ -151,6 +152,9 @@ def main(
         _handle_error(str(error), 2, sapp, meta)
     except ActionFailure as error:
         click.secho(str(error), err=True, fg="red")
+        _handle_error(str(error), 2, sapp, meta)
+    except InvalidGitRepositoryError as error:
+        click.secho("Current directory is not a github repository", err=True, fg="red")
         _handle_error(str(error), 2, sapp, meta)
     except Exception as error:
         # Handles all other errors like FileNotFound, EOF, etc.


### PR DESCRIPTION
Part of https://github.com/returntocorp/semgrep-app/issues/2286

Output before:
```
(semgrep-agent-1j_ha6nY-py3.9) ~/Desktop ᐅ python -m semgrep_agent --config p/r2c --baseline-ref HEAD~1
| versions          - semgrep 0.42.0 on Python 3.9.2
| environment       - running in environment git, triggering event is 'unknown'
| manage            - not logged in
=== setting up agent configuration
| using semgrep rules from https://semgrep.dev/c/p/r2c
An unexpected error occurred
ERROR:root:/Users/sabrinabrogren/Desktop
Traceback (most recent call last):
  File "/Users/sabrinabrogren/Desktop/semgrep-action/src/semgrep_agent/main.py", line 141, in main
    protected_main(**locals())
  File "/Users/sabrinabrogren/Desktop/semgrep-action/src/semgrep_agent/main.py", line 284, in protected_main
    committed_datetime = meta.commit.committed_datetime if meta.commit else None
  File "/Users/sabrinabrogren/Library/Caches/pypoetry/virtualenvs/semgrep-agent-1j_ha6nY-py3.9/lib/python3.9/site-packages/boltons/cacheutils.py", line 610, in __get__
    value = obj.__dict__[self.func.__name__] = self.func(obj)
  File "/Users/sabrinabrogren/Desktop/semgrep-action/src/semgrep_agent/meta.py", line 75, in commit
    commit = self.repo.commit(self.commit_sha)
  File "/Users/sabrinabrogren/Library/Caches/pypoetry/virtualenvs/semgrep-agent-1j_ha6nY-py3.9/lib/python3.9/site-packages/boltons/cacheutils.py", line 610, in __get__
    value = obj.__dict__[self.func.__name__] = self.func(obj)
  File "/Users/sabrinabrogren/Desktop/semgrep-action/src/semgrep_agent/meta.py", line 45, in repo
    repo = gitpython.Repo(".", search_parent_directories=True)
  File "/Users/sabrinabrogren/Library/Caches/pypoetry/virtualenvs/semgrep-agent-1j_ha6nY-py3.9/lib/python3.9/site-packages/git/repo/base.py", line 181, in __init__
    raise InvalidGitRepositoryError(epath)
git.exc.InvalidGitRepositoryError: /Users/sabrinabrogren/Desktop
```

Output now:
```
(semgrep-agent-1j_ha6nY-py3.9) ~/Desktop ᐅ python -m semgrep_agent --config p/r2c --baseline-ref HEAD~1
| versions          - semgrep 0.42.0 on Python 3.9.2
| environment       - running in environment git, triggering event is 'unknown'
| manage            - not logged in
=== setting up agent configuration
| using semgrep rules from https://semgrep.dev/c/p/r2c
Current directory is not a github repository
```