### PR TITLE
Add scan-environment flag

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -115,6 +115,12 @@ def url(string: str) -> str:
     help="Maximum number of seconds to allow Semgrep to run (per file batch; default is 1800 seconds; set to 0 to disable)",
     hidden=True,
 )
+@click.option(
+    "--scan-environment",
+    default="",
+    type=str,
+    hidden=True,
+)
 def main(
     config: str,
     baseline_ref: str,
@@ -125,6 +131,7 @@ def main(
     gitlab_output: bool,
     audit_on: Sequence[str],
     timeout: int,
+    scan_environment: str,
 ) -> NoReturn:
     click.echo(
         get_aligned_command(
@@ -134,7 +141,7 @@ def main(
         err=True,
     )
     # Get metadata from environment variables
-    meta = generate_meta_from_environment(baseline_ref)
+    meta = generate_meta_from_environment(baseline_ref, scan_environment)
     sapp = Sapp(url=publish_url, token=publish_token, deployment_id=publish_deployment)
     # Everything below here is covered by fail-open feature
     try:
@@ -172,6 +179,7 @@ def protected_main(
     gitlab_output: bool,
     audit_on: Sequence[str],
     timeout: int,
+    scan_environment: str,
     sapp: Sapp,
     meta: GitMeta,
 ) -> NoReturn:

--- a/src/semgrep_agent/meta.py
+++ b/src/semgrep_agent/meta.py
@@ -118,7 +118,13 @@ class GitMeta:
             "pull_request_author_image_url": None,
             "pull_request_id": self.pr_id,
             "pull_request_title": self.pr_title,
+            "scan_environment": self.environment,
         }
+
+
+@dataclass
+class LocalScanMeta(GitMeta):
+    environment: str = field(default="local", init=False)
 
 
 @dataclass
@@ -330,7 +336,9 @@ class GitlabMeta(GitMeta):
         return os.getenv("CI_MERGE_REQUEST_TITLE")
 
 
-def generate_meta_from_environment(baseline_ref: Optional[str]) -> GitMeta:
+def generate_meta_from_environment(
+    baseline_ref: Optional[str], scan_environment: Optional[str]
+) -> GitMeta:
     # https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
     if os.getenv("GITHUB_ACTIONS") == "true":
         return GithubMeta(baseline_ref)
@@ -348,4 +356,7 @@ def generate_meta_from_environment(baseline_ref: Optional[str]) -> GitMeta:
                 ),
                 err=True,
             )
+        if scan_environment == "local":
+            return LocalScanMeta(baseline_ref)
+
         return GitMeta(baseline_ref)


### PR DESCRIPTION
The scan environment flag records where the scan took place (e.g.
locally vs GitHub vs GitLab). For folks who connect to the Semgrep App,
this data will be stored to show folks the environment where the last
scan took place.