### PR TITLE
Dockerfile: Remove poetry cache after source installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --no-cache --virtual=.build-deps build-base libffi-dev openssl-dev &
     rm -rf /root/.cache/* /tmp/*
 
 COPY ./src/semgrep_agent /app/src/semgrep_agent
-RUN poetry install --no-dev
+RUN poetry install --no-dev && /root/.cache/*
 
 ENV PATH=/root/.local/bin:${PATH}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM python:3.9.5-alpine
 
 WORKDIR /app
-COPY poetry.lock ./
-COPY pyproject.toml ./
+COPY poetry.lock pyproject.toml ./
 
 ENV INSTALLED_SEMGREP_VERSION=0.52.0
 
@@ -11,9 +10,10 @@ ENV INSTALLED_SEMGREP_VERSION=0.52.0
 RUN apk add --no-cache --virtual=.build-deps build-base libffi-dev openssl-dev &&\
     apk add --no-cache --virtual=.run-deps bash git less libffi openssl &&\
     # Need to pin cryptography version to avoid Rust compiler dependency
-    pip install --no-cache-dir cryptography==3.3.2 poetry==1.1.6 &&\
-    pip install --no-cache-dir pipx &&\
+    pip install --no-cache-dir pipx~=0.16.1.0 &&\
     pipx install semgrep==${INSTALLED_SEMGREP_VERSION} &&\
+    (pip freeze | xargs pip uninstall -y) &&\
+    pip install --no-cache-dir cryptography==3.3.2 poetry==1.1.6 &&\
     poetry config virtualenvs.create false &&\
     # Don't install dev dependencies or semgrep-agent
     poetry install --no-dev --no-root &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,13 @@ RUN apk add --no-cache --virtual=.build-deps build-base libffi-dev openssl-dev &
     # Don't install dev dependencies or semgrep-agent
     poetry install --no-dev --no-root &&\
     apk del .build-deps &&\
-    rm -rf /root/.cache/* /tmp/*
+    rm -rf /root/.cache/* /tmp/* &&\
+    find . \( -name '*.pyc' -o -path '*/__pycache__*' \) -delete
 
 COPY ./src/semgrep_agent /app/src/semgrep_agent
 RUN poetry install --no-dev &&\
-    rm -rf /root/.cache/* /tmp/*
+    rm -rf /root/.cache/* /tmp/* &&\
+    find . \( -name '*.pyc' -o -path '*/__pycache__*' \) -delete
 
 ENV PATH=/root/.local/bin:${PATH}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN apk add --no-cache --virtual=.build-deps build-base libffi-dev openssl-dev &
     rm -rf /root/.cache/* /tmp/*
 
 COPY ./src/semgrep_agent /app/src/semgrep_agent
-RUN poetry install --no-dev && /root/.cache/*
+RUN poetry install --no-dev &&\
+    rm -rf /root/.cache/* /tmp/*
 
 ENV PATH=/root/.local/bin:${PATH}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,12 @@ RUN apk add --no-cache --virtual=.build-deps build-base libffi-dev openssl-dev &
     poetry install --no-dev --no-root &&\
     apk del .build-deps &&\
     rm -rf /root/.cache/* /tmp/* &&\
-    find . \( -name '*.pyc' -o -path '*/__pycache__*' \) -delete
+    find / \( -name '*.pyc' -o -path '*/__pycache__*' \) -delete
 
 COPY ./src/semgrep_agent /app/src/semgrep_agent
 RUN poetry install --no-dev &&\
     rm -rf /root/.cache/* /tmp/* &&\
-    find . \( -name '*.pyc' -o -path '*/__pycache__*' \) -delete
+    find / \( -name '*.pyc' -o -path '*/__pycache__*' \) -delete
 
 ENV PATH=/root/.local/bin:${PATH}
 


### PR DESCRIPTION
- Before: [108.19 MB](https://hub.docker.com/layers/returntocorp/semgrep-agent/develop/images/sha256-9e61bb7f7fe42de9e0d181f784f1d3d7f58e98f8e633856996b2d261ab36b6aa?context=explore)
- After: [99.71 MB](https://hub.docker.com/layers/returntocorp/semgrep-agent/pr-288/images/sha256-4d9d89c3086abfc6d75194360a9d2923fa39f4c38f5553682578f531762c29f5?context=explore)

not a huge improvement so I don't mind if we don't merge this and instead keep the dockerfile simpler