### PR TITLE
Allow users to opt out of metrics with the --disable-metrics flag

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -47,7 +47,7 @@ Scan data provide information on the environment and performance of Semgrep. The
 
 Findings data are used to provide human readable content for notifications and integrations, as well tracking results as new, fixed, or duplicate. The classes of data included are:
 
-- Check ID and metadata (as defined in the rule definition, e.g. OWASP category, message, severity)
+- Check ID and metadata (as defined in the rule definition; e.g. OWASP category, message, severity)
 - Code location, including file path, that triggered findings
 - A one-way hash of a unique code identifier that includes the triggering code content
 - Code content is not collected

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -12,11 +12,15 @@ Scan data provide information on the environment and performance of Semgrep. The
 - Scan metadata, including type of scan and scan parameters (e.g. files or branches to ignore)
 - Review and review-requester identifying data (e.g pull-request ID, branch, merge base, request author)
 - Semgrep environment (e.g. version, interpreter, timestamp)
+- Semgrep performance (scan duration and one-way hashes of rules that ran)
+- Project size in bytes
+- Errors (compile-time errors and return codes)
 
 ## Findings data
 
 Findings data are used to provide human readable content for notifications and integrations, as well tracking results as new, fixed, or duplicate. The classes of data included are:
 - Check ID and metadata (as defined in the rule definition; e.g. OWASP category, message, severity)
 - Code location, including file path, that triggered finding
+- A one-way hash of rule definitions that yield findings
 - A one-way hash of a unique code identifier that includes the triggering code content
 - **Code content is not collected**

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -22,7 +22,7 @@ Semgrep CI collects opt-out non-identifiable aggregate metrics for improving the
 
 ## Opt-out behavior
 
-Semgrep CI’s metrics can be disabled by setting the environment variable SEMGREP_SEND_METRICS=0 or using the flag --disable-metrics. If this environment variable or flag is not set, aggregate metrics are enabled.
+Semgrep CI’s metrics can be disabled by setting the environment variable `SEMGREP_SEND_METRICS=0` or using the flag `--disable-metrics`. If this environment variable or flag is not set, aggregate metrics are enabled.
 
 
 ## Data with Semgrep App only

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -12,9 +12,9 @@ Semgrep CI (also known as semgrep-action or semgrep-agent) may collect non-ident
 
 These principles inform our decisions around data collection:
 
-1. *Transparency*: Collect and use data in a way that is clearly explained to the user and benefits them
-2. *User control*: Put users in control of their data at all times
-3. *Limited data*: Collect what is needed, de-identify where possible, and delete when no longer necessary
+1. **Transparency**: Collect and use data in a way that is clearly explained to the user and benefits them
+2. **User control**: Put users in control of their data at all times
+3. **Limited data**: Collect what is needed, de-identify where possible, and delete when no longer necessary
 
 ## Collected data
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -27,7 +27,7 @@ Semgrep CI’s metrics can be disabled by setting the environment variable `SEMG
 
 ## Data with Semgrep App only
 
-For Semgrep App users running Semgrep CI with a SEMGREP_APP_TOKEN set, data is sent to power your dashboard, notification, and finding features. These data are ONLY sent when using Semgrep CI in an App-connected mode and are default-disabled for Semgrep CI users.
+For Semgrep App users running Semgrep CI with a `SEMGREP_APP_TOKEN` set, data is sent to power your dashboard, notification, and finding features. These data are ONLY sent when using Semgrep CI in an App-connected mode and are default-disabled for Semgrep CI users.
 
 Two types of data are sent to r2c servers for this logged-in use case: scan data and findings data.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,26 +1,58 @@
-# Semgrep Privacy Policy
+# Semgrep CI Privacy Policy
 
-Semgrep collects usage data to provide useful results and to help us improve the product. We send two types of data to r2c servers: scan data and findings data.
+Metrics
 
-## Scan data
+Semgrep CI (also known as semgrep-action or semgrep-agent) may collect non-identifiable aggregate metrics to help improve the product. This document describes:
+
+- the principles that guide our data-collection decisions
+- the breakdown of the data that are and are not collected
+- how to opt-out of Semgrep CI’s metrics
+
+Principles
+
+These principles inform our decisions around data collection:
+
+1. *Transparency*: Collect and use data in a way that is clearly explained to the user and benefits them
+2. *User control*: Put users in control of their data at all times
+3. *Limited data*: Collect what is needed, de-identify where possible, and delete when no longer necessary
+
+Collected data
+
+Semgrep CI collects opt-out non-identifiable aggregate metrics for improving the user experience, guiding Semgrep feature development, and identifying regressions. It relies on Semgrep CLI’s metric collection, which is discussed in detail in that project’s PRIVACY.md (https://github.com/returntocorp/semgrep/blob/develop/PRIVACY.md).
+
+Opt-out behavior
+
+Semgrep CI’s metrics can be disabled by setting the environment variable SEMGREP_SEND_METRICS=0 or using the flag --disable-metrics. If this environment variable or flag is not set, aggregate metrics are enabled.
+
+
+Data with Semgrep App only
+
+For Semgrep App users running Semgrep CI with a SEMGREP_APP_TOKEN set, data is sent to power your dashboard, notification, and finding features. These data are ONLY sent when using Semgrep CI in an App-connected mode and are default-disabled for Semgrep CI users.
+
+Two types of data are sent to r2c servers for this logged-in use case: scan data and findings data. 
+
+Scan data
 
 Scan data provide information on the environment and performance of Semgrep. They power dashboards, identify anomalies with the product, and are needed for billing. The classes of data included are:
-- Project identity (e.g. name, URL)
-- Scan environment (e.g. CI provider, OS)
-- Author identity (e.g. committer email)
-- Commit metadata (e.g. commit hash)
-- Scan metadata, including type of scan and scan parameters (e.g. files or branches to ignore)
-- Review and review-requester identifying data (e.g pull-request ID, branch, merge base, request author)
-- Semgrep environment (e.g. version, interpreter, timestamp)
+
+- Project identity (e.g., name, URL)
+- Scan environment (e.g., CI provider, OS)
+- Author identity (e.g., committer email)
+- Commit metadata (e.g., commit hash)
+- Scan metadata, including type of scan and scan parameters (e.g., files or branches to ignore)
+- Review and review-requester identifying data (e.g., pull-request ID, branch, merge base, request author)
+- Semgrep environment (e.g., version, interpreter, timestamp)
 - Semgrep performance (scan duration and one-way hashes of rules that ran)
 - Project size in bytes
 - Errors (compile-time errors and return codes)
 
-## Findings data
+Findings data
 
 Findings data are used to provide human readable content for notifications and integrations, as well tracking results as new, fixed, or duplicate. The classes of data included are:
-- Check ID and metadata (as defined in the rule definition; e.g. OWASP category, message, severity)
-- Code location, including file path, that triggered finding
+
+- Check ID and metadata (as defined in the rule definition, e.g., OWASP category, message, severity)
+- Code location, including file path, that triggered findings
 - A one-way hash of rule definitions that yield findings
 - A one-way hash of a unique code identifier that includes the triggering code content
-- **Code content is not collected**
+- Code content is not collected
+

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Semgrep CI Privacy Policy
 
-Metrics
+## Metrics
 
 Semgrep CI (also known as semgrep-action or semgrep-agent) may collect non-identifiable aggregate metrics to help improve the product. This document describes:
 
@@ -8,7 +8,7 @@ Semgrep CI (also known as semgrep-action or semgrep-agent) may collect non-ident
 - the breakdown of the data that are and are not collected
 - how to opt-out of Semgrep CI’s metrics
 
-Principles
+## Principles
 
 These principles inform our decisions around data collection:
 
@@ -16,22 +16,22 @@ These principles inform our decisions around data collection:
 2. *User control*: Put users in control of their data at all times
 3. *Limited data*: Collect what is needed, de-identify where possible, and delete when no longer necessary
 
-Collected data
+## Collected data
 
 Semgrep CI collects opt-out non-identifiable aggregate metrics for improving the user experience, guiding Semgrep feature development, and identifying regressions. It relies on Semgrep CLI’s metric collection, which is discussed in detail in that project’s [PRIVACY.md](https://github.com/returntocorp/semgrep/blob/develop/PRIVACY.md).
 
-Opt-out behavior
+## Opt-out behavior
 
 Semgrep CI’s metrics can be disabled by setting the environment variable SEMGREP_SEND_METRICS=0 or using the flag --disable-metrics. If this environment variable or flag is not set, aggregate metrics are enabled.
 
 
-Data with Semgrep App only
+## Data with Semgrep App only
 
 For Semgrep App users running Semgrep CI with a SEMGREP_APP_TOKEN set, data is sent to power your dashboard, notification, and finding features. These data are ONLY sent when using Semgrep CI in an App-connected mode and are default-disabled for Semgrep CI users.
 
 Two types of data are sent to r2c servers for this logged-in use case: scan data and findings data. 
 
-Scan data
+### Scan data
 
 Scan data provide information on the environment and performance of Semgrep. They power dashboards, identify anomalies with the product, and are needed for billing. The classes of data included are:
 
@@ -46,7 +46,7 @@ Scan data provide information on the environment and performance of Semgrep. The
 - Project size in bytes
 - Errors (compile-time errors and return codes)
 
-Findings data
+### Findings data
 
 Findings data are used to provide human readable content for notifications and integrations, as well tracking results as new, fixed, or duplicate. The classes of data included are:
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -40,14 +40,14 @@ Scan data provide information on the environment and performance of Semgrep. The
 - Author identity (e.g. committer email)
 - Commit metadata (e.g. commit hash)
 - Scan metadata, including type of scan and scan parameters (e.g. files or branches to ignore)
-- Review and review-requester identifying data (e.g., pull-request ID, branch, merge base, request author)
+- Review and review-requester identifying data (e.g. pull-request ID, branch, merge base, request author)
 - Semgrep environment (e.g. version, interpreter, timestamp)
 
 ### Findings data
 
 Findings data are used to provide human readable content for notifications and integrations, as well tracking results as new, fixed, or duplicate. The classes of data included are:
 
-- Check ID and metadata (as defined in the rule definition, e.g., OWASP category, message, severity)
+- Check ID and metadata (as defined in the rule definition, e.g. OWASP category, message, severity)
 - Code location, including file path, that triggered findings
 - A one-way hash of a unique code identifier that includes the triggering code content
 - Code content is not collected

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -29,22 +29,19 @@ Semgrep CI’s metrics can be disabled by setting the environment variable SEMGR
 
 For Semgrep App users running Semgrep CI with a SEMGREP_APP_TOKEN set, data is sent to power your dashboard, notification, and finding features. These data are ONLY sent when using Semgrep CI in an App-connected mode and are default-disabled for Semgrep CI users.
 
-Two types of data are sent to r2c servers for this logged-in use case: scan data and findings data. 
+Two types of data are sent to r2c servers for this logged-in use case: scan data and findings data.
 
 ### Scan data
 
 Scan data provide information on the environment and performance of Semgrep. They power dashboards, identify anomalies with the product, and are needed for billing. The classes of data included are:
 
-- Project identity (e.g., name, URL)
-- Scan environment (e.g., CI provider, OS)
-- Author identity (e.g., committer email)
-- Commit metadata (e.g., commit hash)
-- Scan metadata, including type of scan and scan parameters (e.g., files or branches to ignore)
+- Project identity (e.g. name, URL)
+- Scan environment (e.g. CI provider, OS)
+- Author identity (e.g. committer email)
+- Commit metadata (e.g. commit hash)
+- Scan metadata, including type of scan and scan parameters (e.g. files or branches to ignore)
 - Review and review-requester identifying data (e.g., pull-request ID, branch, merge base, request author)
-- Semgrep environment (e.g., version, interpreter, timestamp)
-- Semgrep performance (scan duration and one-way hashes of rules that ran)
-- Project size in bytes
-- Errors (compile-time errors and return codes)
+- Semgrep environment (e.g. version, interpreter, timestamp)
 
 ### Findings data
 
@@ -52,7 +49,5 @@ Findings data are used to provide human readable content for notifications and i
 
 - Check ID and metadata (as defined in the rule definition, e.g., OWASP category, message, severity)
 - Code location, including file path, that triggered findings
-- A one-way hash of rule definitions that yield findings
 - A one-way hash of a unique code identifier that includes the triggering code content
 - Code content is not collected
-

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -18,7 +18,7 @@ These principles inform our decisions around data collection:
 
 Collected data
 
-Semgrep CI collects opt-out non-identifiable aggregate metrics for improving the user experience, guiding Semgrep feature development, and identifying regressions. It relies on Semgrep CLI’s metric collection, which is discussed in detail in that project’s PRIVACY.md (https://github.com/returntocorp/semgrep/blob/develop/PRIVACY.md).
+Semgrep CI collects opt-out non-identifiable aggregate metrics for improving the user experience, guiding Semgrep feature development, and identifying regressions. It relies on Semgrep CLI’s metric collection, which is discussed in detail in that project’s [PRIVACY.md](https://github.com/returntocorp/semgrep/blob/develop/PRIVACY.md).
 
 Opt-out behavior
 

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -91,6 +91,12 @@ def url(string: str) -> str:
     help="Your semgrep.dev deployment ID (requires --publish-token)",
 )
 @click.option(
+    "--disable-metrics",
+    envvar="DISABLE_METRICS",
+    is_flag=True,
+    help="Disable anonymized metrics collection (such as scan duration), used to improve Semgrep",
+)
+@click.option(
     "--publish-url",
     envvar="INPUT_PUBLISHURL",
     type=url,
@@ -129,6 +135,7 @@ def main(
     publish_url: str,
     publish_token: str,
     publish_deployment: int,
+    disable_metrics: bool,
     json_output: bool,
     gitlab_output: bool,
     audit_on: Sequence[str],
@@ -180,6 +187,7 @@ def protected_main(
     publish_url: str,
     publish_token: str,
     publish_deployment: int,
+    disable_metrics: bool,
     json_output: bool,
     gitlab_output: bool,
     audit_on: Sequence[str],
@@ -197,6 +205,12 @@ def protected_main(
         ),
         err=True,
     )
+
+    if disable_metrics:
+        click.echo(
+            get_aligned_command("metrics", "disabled"),
+            err=True,
+        )
 
     # Setup URL/Token
     if sapp.is_configured:
@@ -307,6 +321,7 @@ def protected_main(
         meta.head_ref,
         semgrep.get_semgrepignore(sapp.scan.ignore_patterns),
         sapp.is_configured,
+        disable_metrics,
         timeout=(timeout if timeout > 0 else None),
     )
 

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -92,7 +92,7 @@ def url(string: str) -> str:
 )
 @click.option(
     "--enable-metrics/--disable-metrics",
-    envvar="ENABLE_METRICS",
+    envvar="SEMGREP_SEND_METRICS",
     default=True,
     is_flag=True,
     help="Enable (default) or disable anonymized metrics used to improve Semgrep",

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -91,7 +91,9 @@ def url(string: str) -> str:
     help="Your semgrep.dev deployment ID (requires --publish-token)",
 )
 @click.option(
-    "--disable-metrics",
+    "--enable-metrics/--disable-metrics",
+    envvar="ENABLE_METRICS",
+    default=False
     envvar="DISABLE_METRICS",
     is_flag=True,
     help="Disable anonymized metrics collection (such as scan duration), used to improve Semgrep",

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -93,10 +93,9 @@ def url(string: str) -> str:
 @click.option(
     "--enable-metrics/--disable-metrics",
     envvar="ENABLE_METRICS",
-    default=False
-    envvar="DISABLE_METRICS",
+    default=True,
     is_flag=True,
-    help="Disable anonymized metrics collection (such as scan duration), used to improve Semgrep",
+    help="Enable (default) or disable anonymized metrics used to improve Semgrep",
 )
 @click.option(
     "--publish-url",
@@ -137,7 +136,7 @@ def main(
     publish_url: str,
     publish_token: str,
     publish_deployment: int,
-    disable_metrics: bool,
+    enable_metrics: bool,
     json_output: bool,
     gitlab_output: bool,
     audit_on: Sequence[str],
@@ -189,7 +188,7 @@ def protected_main(
     publish_url: str,
     publish_token: str,
     publish_deployment: int,
-    disable_metrics: bool,
+    enable_metrics: bool,
     json_output: bool,
     gitlab_output: bool,
     audit_on: Sequence[str],
@@ -208,7 +207,7 @@ def protected_main(
         err=True,
     )
 
-    if disable_metrics:
+    if not enable_metrics:
         click.echo(
             get_aligned_command("metrics", "disabled"),
             err=True,
@@ -315,7 +314,6 @@ def protected_main(
         sys.exit(1)
 
     committed_datetime = meta.commit.committed_datetime if meta.commit else None
-
     results = semgrep.scan(
         config,
         committed_datetime,
@@ -323,7 +321,7 @@ def protected_main(
         meta.head_ref,
         semgrep.get_semgrepignore(sapp.scan.ignore_patterns),
         sapp.is_configured,
-        disable_metrics,
+        enable_metrics,
         timeout=(timeout if timeout > 0 else None),
     )
 

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -105,6 +105,7 @@ def get_findings(
     head_ref: Optional[str],
     semgrep_ignore: TextIO,
     uses_managed_policy: bool,
+    disable_metrics: bool,
     *,
     timeout: Optional[int],
 ) -> FindingSets:
@@ -123,7 +124,7 @@ def get_findings(
         for conf in config_specifier:
             config_args.extend(["--config", conf])
         rewrite_args = ["--no-rewrite-rule-ids"] if uses_managed_policy else []
-
+        metrics_args = ["--enable-metrics"] if not disable_metrics else []
         debug_echo("=== seeing if there are any findings")
         findings = FindingSets()
 
@@ -138,6 +139,7 @@ def get_findings(
                 "--json",
                 "--autofix",
                 "--dryrun",
+                *metrics_args,
                 *rewrite_args,
                 *config_args,
             ]
@@ -189,6 +191,7 @@ def get_findings(
                 args = [
                     "--skip-unknown-extensions",
                     "--json",
+                    "--disable-metrics",  # only count one semgrep run per semgrep-agent run
                     *rewrite_args,
                     *config_args,
                 ]
@@ -283,6 +286,7 @@ def scan(
     head_ref: Optional[str],
     semgrep_ignore: TextIO,
     uses_managed_policy: bool,
+    disable_metrics: bool,
     *,
     timeout: Optional[int],
 ) -> Results:
@@ -295,6 +299,7 @@ def scan(
             head_ref,
             semgrep_ignore,
             uses_managed_policy,
+            disable_metrics,
             timeout=timeout,
         )
     except sh.ErrorReturnCode as error:

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -105,7 +105,7 @@ def get_findings(
     head_ref: Optional[str],
     semgrep_ignore: TextIO,
     uses_managed_policy: bool,
-    disable_metrics: bool,
+    enable_metrics: bool,
     *,
     timeout: Optional[int],
 ) -> FindingSets:
@@ -124,7 +124,7 @@ def get_findings(
         for conf in config_specifier:
             config_args.extend(["--config", conf])
         rewrite_args = ["--no-rewrite-rule-ids"] if uses_managed_policy else []
-        metrics_args = [] if disable_metrics else ["--enable-metrics"]
+        metrics_args = ["--enable-metrics"] if enable_metrics else []
         debug_echo("=== seeing if there are any findings")
         findings = FindingSets()
 
@@ -286,7 +286,7 @@ def scan(
     head_ref: Optional[str],
     semgrep_ignore: TextIO,
     uses_managed_policy: bool,
-    disable_metrics: bool,
+    enable_metrics: bool,
     *,
     timeout: Optional[int],
 ) -> Results:
@@ -299,7 +299,7 @@ def scan(
             head_ref,
             semgrep_ignore,
             uses_managed_policy,
-            disable_metrics,
+            enable_metrics,
             timeout=timeout,
         )
     except sh.ErrorReturnCode as error:

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -124,7 +124,7 @@ def get_findings(
         for conf in config_specifier:
             config_args.extend(["--config", conf])
         rewrite_args = ["--no-rewrite-rule-ids"] if uses_managed_policy else []
-        metrics_args = ["--enable-metrics"] if not disable_metrics else []
+        metrics_args = [] if disable_metrics else ["--enable-metrics"]
         debug_echo("=== seeing if there are any findings")
         findings = FindingSets()
 


### PR DESCRIPTION
This PR adds the the ability for Semgrep CI to collect opt-out non-identifiable aggregate metrics for improving the user experience, guiding Semgrep feature development, and identifying regressions. It relies on Semgrep CLI’s metric collection, which is discussed in detail in that project’s [PRIVACY.md](https://github.com/returntocorp/semgrep/blob/develop/PRIVACY.md).

Users can opt-out of metrics by setting the environment variable `SEMGREP_SEND_METRICS=0` or Semgrep CI’s CLI flag `--disable-metrics`.

We have aggressive performance goals for Semgrep CI so capturing these metrics helps us understand real-world performance and be data-driven in prioritization.

The specific metrics collected by Semgrep CI, descriptions of fields, example values, and additional context are included in this project’s PRIVACY.md file (updated as part of this PR).

Changes:

- Run Semgrep CI with metrics enabled by default
- Allow users to opt out of metrics with the `--disable-metrics` flag (and `SEMGREP_SEND_METRICS` env variable)
- Never collect metrics on the baselining run, as this would double count