### PR TITLE
Improve messaging on what happens when config and policy are both present

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -235,14 +235,17 @@ def protected_main(
     click.echo("=== setting up agent configuration", err=True)
     if config:
         if sapp.is_configured:
-            click.secho(
-                f"\nDetected a config flag: no longer using rules configured on the web.",
-                fg="yellow",
-            )
-            click.echo(
-                f"If you wish to use Semgrep Cloud features, please remove the config flag\n"
-                "and add rules and rulesets to your policies instead.\n"
-            )
+            message = """
+            === [ERROR] Detected config flag while logged in
+
+            Semgrep will only run rules with the Semgrep Cloud features
+            if they are in your policy (see semgrep.dev/manage/policies).
+            If you intended to use Semgrep Cloud, please remove the config
+            flag and add rules/rulesets to your policies instead.
+            """
+            message = dedent(message).strip()
+            click.secho(message, err=True, fg="red")
+            sys.exit(1)
         resolved_config = []
         for conf in config:
             resolved = semgrep.resolve_config_shorthand(conf)
@@ -253,7 +256,7 @@ def protected_main(
         local_config_path, num_rules, cai_rules = sapp.download_rules()
         if num_rules == 0:
             message = """
-            == [ERROR] This policy will not run any rules
+            === [ERROR] This policy will not run any rules
 
             Semgrep will only run rules in your policy that
             have an action associated with them (notify or block).
@@ -263,7 +266,7 @@ def protected_main(
             channels on the notifications tab
             """
             message = dedent(message).strip()
-            click.echo(message, err=True)
+            click.secho(message, err=True, fg="red")
             sys.exit(1)
         config = (str(local_config_path),)
         click.echo(

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -231,19 +231,18 @@ def protected_main(
         if os.getenv(env_var):
             click.echo(get_aligned_command(env_var, str(os.getenv(env_var))))
 
-    if config and sapp.is_configured:
-        click.secho(
-            f"\nDetected a config flag: no longer using rules configured on the web.",
-            fg="yellow",
-        )
-        click.echo(
-            f"If you wish to use Semgrep Cloud features, please remove the config flag\n"
-            "and add rules and rulesets to your policies instead.\n"
-        )
-
     # Setup Config
     click.echo("=== setting up agent configuration", err=True)
     if config:
+        if sapp.is_configured:
+            click.secho(
+                f"\nDetected a config flag: no longer using rules configured on the web.",
+                fg="yellow",
+            )
+            click.echo(
+                f"If you wish to use Semgrep Cloud features, please remove the config flag\n"
+                "and add rules and rulesets to your policies instead.\n"
+            )
         resolved_config = []
         for conf in config:
             resolved = semgrep.resolve_config_shorthand(conf)

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -231,6 +231,16 @@ def protected_main(
         if os.getenv(env_var):
             click.echo(get_aligned_command(env_var, str(os.getenv(env_var))))
 
+    if config and sapp.is_configured:
+        click.secho(
+            f"\nDetected a config flag: no longer using rules configured on the web.",
+            fg="yellow",
+        )
+        click.echo(
+            f"If you wish to use Semgrep Cloud features, please remove the config flag\n"
+            "and add rules and rulesets to your policies instead.\n"
+        )
+
     # Setup Config
     click.echo("=== setting up agent configuration", err=True)
     if config:


### PR DESCRIPTION
If users supply a config and also publishDeployment/publishToken to log in, this is likely an error, so let's message about it really loudly.

<img width="959" alt="Screen Shot 2021-06-07 at 12 13 28 PM" src="https://user-images.githubusercontent.com/25408780/121075217-c5eca780-c789-11eb-8535-30bfcd4f87ef.png">

