### PR TITLE
Allow users to override our default behavior of rewrite rule-ids

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -329,7 +329,7 @@ def protected_main(
         meta.base_commit_ref,
         meta.head_ref,
         semgrep.get_semgrepignore(sapp.scan.ignore_patterns),
-        rewrite_rule_ids,
+        rewrite_rule_ids and not sapp.is_configured,
         enable_metrics,
         timeout=(timeout if timeout > 0 else None),
     )

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -102,7 +102,8 @@ def url(string: str) -> str:
     envvar="REWRITE_RULE_IDS",
     default=True,
     is_flag=True,
-    help="Specify whether semgrep should or should not rewrite rule-ids based on directory structure",
+    help="Specify whether semgrep should or should not rewrite rule-ids based on directory structure (MAY BE DEPRECATED ONCE ANY ARBITRARY SEMGREP CLI FLAG CAN BE PASSED IN)",
+    hidden=True,
 )
 @click.option(
     "--publish-url",

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -98,6 +98,13 @@ def url(string: str) -> str:
     help="Enable (default) or disable anonymized metrics used to improve Semgrep",
 )
 @click.option(
+    "--rewrite-rule-ids/--no-rewrite-rule-ids",
+    envvar="REWRITE_RULE_IDS",
+    default=True,
+    is_flag=True,
+    help="Specify whether semgrep should or should not rewrite rule-ids based on directory structure",
+)
+@click.option(
     "--publish-url",
     envvar="INPUT_PUBLISHURL",
     type=url,
@@ -137,6 +144,7 @@ def main(
     publish_token: str,
     publish_deployment: int,
     enable_metrics: bool,
+    rewrite_rule_ids: bool,
     json_output: bool,
     gitlab_output: bool,
     audit_on: Sequence[str],
@@ -189,6 +197,7 @@ def protected_main(
     publish_token: str,
     publish_deployment: int,
     enable_metrics: bool,
+    rewrite_rule_ids: bool,
     json_output: bool,
     gitlab_output: bool,
     audit_on: Sequence[str],
@@ -320,7 +329,7 @@ def protected_main(
         meta.base_commit_ref,
         meta.head_ref,
         semgrep.get_semgrepignore(sapp.scan.ignore_patterns),
-        sapp.is_configured,
+        rewrite_rule_ids,
         enable_metrics,
         timeout=(timeout if timeout > 0 else None),
     )

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -123,11 +123,7 @@ def get_findings(
         config_args = []
         for conf in config_specifier:
             config_args.extend(["--config", conf])
-        rewrite_args = (
-            []
-            if ".semgrep/" in config_specifier and rewrite_rule_ids
-            else ["--no-rewrite-rule-ids"]
-        )
+        rewrite_args = [] if rewrite_rule_ids else ["--no-rewrite-rule-ids"]
         metrics_args = ["--enable-metrics"] if enable_metrics else []
         debug_echo("=== seeing if there are any findings")
         findings = FindingSets()

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -104,7 +104,7 @@ def get_findings(
     base_commit_ref: Optional[str],
     head_ref: Optional[str],
     semgrep_ignore: TextIO,
-    uses_managed_policy: bool,
+    rewrite_rule_ids: bool,
     enable_metrics: bool,
     *,
     timeout: Optional[int],
@@ -123,7 +123,11 @@ def get_findings(
         config_args = []
         for conf in config_specifier:
             config_args.extend(["--config", conf])
-        rewrite_args = ["--no-rewrite-rule-ids"] if uses_managed_policy else []
+        rewrite_args = (
+            []
+            if ".semgrep/" in config_specifier and rewrite_rule_ids
+            else ["--no-rewrite-rule-ids"]
+        )
         metrics_args = ["--enable-metrics"] if enable_metrics else []
         debug_echo("=== seeing if there are any findings")
         findings = FindingSets()
@@ -285,7 +289,7 @@ def scan(
     base_commit_ref: Optional[str],
     head_ref: Optional[str],
     semgrep_ignore: TextIO,
-    uses_managed_policy: bool,
+    rewrite_rule_ids: bool,
     enable_metrics: bool,
     *,
     timeout: Optional[int],
@@ -298,7 +302,7 @@ def scan(
             base_commit_ref,
             head_ref,
             semgrep_ignore,
-            uses_managed_policy,
+            rewrite_rule_ids,
             enable_metrics,
             timeout=timeout,
         )


### PR DESCRIPTION
Allow users to override our default behavior of rewriting rule-ids when their rules are stored in a .semgrep/ directory, the same way they would be able to with semgrep CLI.

Fixes #290 