### PR TITLE
Cm/gitlab mr comments

### DIFF
--- a/src/semgrep_agent/meta.py
+++ b/src/semgrep_agent/meta.py
@@ -338,6 +338,16 @@ class GitlabMeta(GitMeta):
     def pr_title(self) -> Optional[str]:
         return os.getenv("CI_MERGE_REQUEST_TITLE")
 
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            **super().to_dict(),
+            "branch": self.commit_ref,
+            "base_sha": self.base_commit_ref,
+            "start_sha": os.getenv("CI_MERGE_REQUEST_DIFF_BASE_SHA"),
+            "source_sha": os.getenv("CI_MERGE_REQUEST_SOURCE_BRANCH_SHA"),
+            "target_sha": os.getenv("CI_MERGE_REQUEST_TARGET_BRANCH_SHA"),
+        }
+
 
 def generate_meta_from_environment(
     baseline_ref: Optional[str], scan_environment: Optional[str]

--- a/src/semgrep_agent/meta.py
+++ b/src/semgrep_agent/meta.py
@@ -344,8 +344,6 @@ class GitlabMeta(GitMeta):
             "branch": self.commit_ref,
             "base_sha": self.base_commit_ref,
             "start_sha": os.getenv("CI_MERGE_REQUEST_DIFF_BASE_SHA"),
-            "source_sha": os.getenv("CI_MERGE_REQUEST_SOURCE_BRANCH_SHA"),
-            "target_sha": os.getenv("CI_MERGE_REQUEST_TARGET_BRANCH_SHA"),
         }
 
 

--- a/src/semgrep_agent/meta.py
+++ b/src/semgrep_agent/meta.py
@@ -335,6 +335,10 @@ class GitlabMeta(GitMeta):
         return os.getenv("CI_MERGE_REQUEST_IID")
 
     @cachedproperty
+    def start_sha(self) -> Optional[str]:
+        return os.getenv("CI_MERGE_REQUEST_DIFF_BASE_SHA")
+
+    @cachedproperty
     def pr_title(self) -> Optional[str]:
         return os.getenv("CI_MERGE_REQUEST_TITLE")
 
@@ -343,7 +347,7 @@ class GitlabMeta(GitMeta):
             **super().to_dict(),
             "branch": self.commit_ref,
             "base_sha": self.base_commit_ref,
-            "start_sha": os.getenv("CI_MERGE_REQUEST_DIFF_BASE_SHA"),
+            "start_sha": self.start_sha,
         }
 
 

--- a/src/semgrep_agent/meta.py
+++ b/src/semgrep_agent/meta.py
@@ -37,7 +37,7 @@ class GitMeta:
     @cachedproperty
     def event_name(self) -> str:
         if self.pr_id:
-            return "pull-request"
+            return "pull_request"
         return "unknown"
 
     @cachedproperty
@@ -325,7 +325,10 @@ class GitlabMeta(GitMeta):
 
     @cachedproperty
     def event_name(self) -> str:
-        return os.getenv("CI_PIPELINE_SOURCE", "unknown")
+        gitlab_event_name = os.getenv("CI_PIPELINE_SOURCE", "unknown")
+        if gitlab_event_name in ["merge_request_event", "external_pull_request_event"]:
+            return "pull_request"
+        return gitlab_event_name
 
     @cachedproperty
     def pr_id(self) -> Optional[str]:

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tempfile
+import time
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
@@ -196,6 +197,7 @@ class Sapp:
             },
             timeout=30,
         )
+        time.sleep(1200)
         debug_echo(f"=== POST .../findings responded: {response!r}")
         try:
             response.raise_for_status()

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -81,7 +81,6 @@ class Sapp:
         returns name of policy used to scan
         """
         debug_echo(f"=== reporting start to semgrep app at {self.url}")
-        
         response = self.session.post(
             f"{self.url}/api/agent/deployment/{self.deployment_id}/scan",
             json={"meta": meta.to_dict()},

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -81,6 +81,7 @@ class Sapp:
         returns name of policy used to scan
         """
         debug_echo(f"=== reporting start to semgrep app at {self.url}")
+
         response = self.session.post(
             f"{self.url}/api/agent/deployment/{self.deployment_id}/scan",
             json={"meta": meta.to_dict()},

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -81,7 +81,7 @@ class Sapp:
         returns name of policy used to scan
         """
         debug_echo(f"=== reporting start to semgrep app at {self.url}")
-
+        debug_echo(str(meta.to_dict()))
         response = self.session.post(
             f"{self.url}/api/agent/deployment/{self.deployment_id}/scan",
             json={"meta": meta.to_dict()},

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -188,6 +188,7 @@ class Sapp:
             json={
                 # send a backup token in case the app is not available
                 "token": os.getenv("GITHUB_TOKEN"),
+                "gitlab_token": os.getenv("CI_JOB_TOKEN"),
                 "findings": [
                     finding.to_dict(omit=fields_to_omit)
                     for finding in results.findings.new

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -1,7 +1,6 @@
 import json
 import os
 import tempfile
-import time
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
@@ -189,7 +188,7 @@ class Sapp:
             json={
                 # send a backup token in case the app is not available
                 "token": os.getenv("GITHUB_TOKEN"),
-                "gitlab_token": os.getenv("CI_JOB_TOKEN"),
+                "gitlab_token": os.getenv("GITLAB_TOKEN"),
                 "findings": [
                     finding.to_dict(omit=fields_to_omit)
                     for finding in results.findings.new
@@ -197,7 +196,6 @@ class Sapp:
             },
             timeout=30,
         )
-        time.sleep(1200)
         debug_echo(f"=== POST .../findings responded: {response!r}")
         try:
             response.raise_for_status()

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -81,7 +81,6 @@ class Sapp:
         returns name of policy used to scan
         """
         debug_echo(f"=== reporting start to semgrep app at {self.url}")
-        debug_echo(str(meta.to_dict()))
         response = self.session.post(
             f"{self.url}/api/agent/deployment/{self.deployment_id}/scan",
             json={"meta": meta.to_dict()},

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -81,6 +81,7 @@ class Sapp:
         returns name of policy used to scan
         """
         debug_echo(f"=== reporting start to semgrep app at {self.url}")
+        
         response = self.session.post(
             f"{self.url}/api/agent/deployment/{self.deployment_id}/scan",
             json={"meta": meta.to_dict()},


### PR DESCRIPTION
Currently inline MR comments just look like this, with the rule's message displayed. Changes to semgrep-app will continue to improve the appearance and style of these comments. Once gitlab-auth is finished, we can use app tokens like we do in GitHub and it will look like the comment came from Semgrep rather than from the person who opened the MR.

<img width="807" alt="Screen Shot 2021-06-14 at 11 12 39 PM" src="https://user-images.githubusercontent.com/25408780/122001982-06d65480-cd66-11eb-83ee-641e8739f71d.png">
