### PR TITLE
Report searched paths

### DIFF
--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -5,6 +5,7 @@ import uuid
 from dataclasses import dataclass
 from dataclasses import field
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 from typing import Collection
 from typing import Dict
@@ -212,6 +213,7 @@ class FindingSets:
     baseline: FindingSet = field(default_factory=FindingSet)
     current: FindingSet = field(default_factory=FindingSet)
     ignored: FindingSet = field(default_factory=FindingSet)
+    ignored_paths: Set[Path] = field(default_factory=set)
 
     @property
     def new(self) -> Set[Finding]:

--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -213,7 +213,7 @@ class FindingSets:
     baseline: FindingSet = field(default_factory=FindingSet)
     current: FindingSet = field(default_factory=FindingSet)
     ignored: FindingSet = field(default_factory=FindingSet)
-    ignored_paths: Set[Path] = field(default_factory=set)
+    searched_paths: Set[Path] = field(default_factory=set)
 
     @property
     def new(self) -> Set[Finding]:

--- a/src/semgrep_agent/ignores.py
+++ b/src/semgrep_agent/ignores.py
@@ -119,7 +119,6 @@ class FileIgnore(Mapping[Path, Entry]):
                     yield Entry(Path(e.path), False)
 
     def _init_cache(self) -> None:
-        debug_echo(f"Ignored patterns are:\n{self.patterns}")
         before = time.time()
         self._walk_cache = {}
         for target in self.target_paths:

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -132,6 +132,9 @@ def get_findings(
             click.echo(
                 "=== looking for current issues in " + unit_len(paths, "file"), err=True
             )
+            if len(paths) < 100:
+                for path in paths:
+                    debug_echo(f"searching {str(path)}")
 
             args = [
                 "--skip-unknown-extensions",

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -126,7 +126,7 @@ def get_findings(
         rewrite_args = [] if rewrite_rule_ids else ["--no-rewrite-rule-ids"]
         metrics_args = ["--enable-metrics"] if enable_metrics else []
         debug_echo("=== seeing if there are any findings")
-        findings = FindingSets(ignored_paths=set(targets.ignored_paths))
+        findings = FindingSets(searched_paths=set(targets.searched_paths))
 
         with targets.current_paths() as paths:
             click.echo(

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -132,9 +132,9 @@ def get_findings(
             click.echo(
                 "=== looking for current issues in " + unit_len(paths, "file"), err=True
             )
-            if len(paths) < 100:
-                for path in paths:
-                    debug_echo(f"searching {str(path)}")
+
+            for path in paths:
+                debug_echo(f"searching {str(path)}")
 
             args = [
                 "--skip-unknown-extensions",

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -116,7 +116,7 @@ def get_findings(
         targets = TargetFileManager(
             base_path=workdir,
             base_commit=base_ref,
-            paths=[workdir],
+            all_paths=[workdir],
             ignore_rules_file=semgrep_ignore,
         )
 
@@ -126,7 +126,7 @@ def get_findings(
         rewrite_args = [] if rewrite_rule_ids else ["--no-rewrite-rule-ids"]
         metrics_args = ["--enable-metrics"] if enable_metrics else []
         debug_echo("=== seeing if there are any findings")
-        findings = FindingSets()
+        findings = FindingSets(ignored_paths=set(targets.ignored_paths))
 
         with targets.current_paths() as paths:
             click.echo(

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -212,6 +212,7 @@ class Sapp:
             f"{self.url}/api/agent/scan/{self.scan.id}/ignores",
             json={
                 "findings": [finding.to_dict() for finding in results.findings.ignored],
+                "ignored_paths": list(results.findings.ignored_paths),
             },
             timeout=30,
         )

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -193,7 +193,7 @@ class Sapp:
                     finding.to_dict(omit=fields_to_omit)
                     for finding in results.findings.new
                 ],
-                "searched_paths": list(results.findings.searched_paths),
+                "searched_paths": [str(p) for p in results.findings.searched_paths],
             },
             timeout=30,
         )

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -193,6 +193,7 @@ class Sapp:
                     finding.to_dict(omit=fields_to_omit)
                     for finding in results.findings.new
                 ],
+                "searched_paths": list(results.findings.searched_paths),
             },
             timeout=30,
         )
@@ -212,7 +213,6 @@ class Sapp:
             f"{self.url}/api/agent/scan/{self.scan.id}/ignores",
             json={
                 "findings": [finding.to_dict() for finding in results.findings.ignored],
-                "ignored_paths": list(results.findings.ignored_paths),
             },
             timeout=30,
         )

--- a/src/semgrep_agent/targets.py
+++ b/src/semgrep_agent/targets.py
@@ -392,10 +392,10 @@ class TargetFileManager:
         yield self._paths.targeted
 
     @property
-    def ignored_paths(self) -> List[Path]:
+    def searched_paths(self) -> List[Path]:
         """
         Return list of paths that have been ignored.
 
         :return: A list of paths
         """
-        return self._paths.ignored
+        return self._paths.targeted

--- a/src/semgrep_agent/targets.py
+++ b/src/semgrep_agent/targets.py
@@ -227,6 +227,9 @@ class TargetFileManager:
                 f"| skipping {unit_len(ignored_paths, 'file')} based on path ignore rules",
                 err=True,
             )
+            if len(patterns) < 100:
+                for p in patterns:
+                    debug_echo(f"skipping {p}")
 
         relative_survived_paths = [
             path.relative_to(self._base_path) for path in survived_paths

--- a/src/semgrep_agent/targets.py
+++ b/src/semgrep_agent/targets.py
@@ -227,9 +227,9 @@ class TargetFileManager:
                 f"| skipping {unit_len(ignored_paths, 'file')} based on path ignore rules",
                 err=True,
             )
-            if len(patterns) < 100:
-                for p in patterns:
-                    debug_echo(f"skipping {p}")
+
+            for p in patterns:
+                debug_echo(f"Ignoring files matching pattern '{p}'")
 
         relative_survived_paths = [
             path.relative_to(self._base_path) for path in survived_paths

--- a/src/semgrep_agent/targets.py
+++ b/src/semgrep_agent/targets.py
@@ -397,8 +397,8 @@ class TargetFileManager:
     @property
     def searched_paths(self) -> List[Path]:
         """
-        Return list of paths that have been ignored.
+        The list of paths that have been searched with Semgrep
 
-        :return: A list of paths
+        :return: A list of paths NOT ignored, all relative to root directory
         """
         return self._paths.targeted

--- a/src/semgrep_agent/targets.py
+++ b/src/semgrep_agent/targets.py
@@ -50,6 +50,12 @@ class StatusCode:
 
 
 @attr.s
+class PathLists:
+    targeted = attr.ib(type=List[Path])
+    ignored = attr.ib(type=List[Path])
+
+
+@attr.s
 class TargetFileManager:
     """
     Handles all logic related to knowing what files to run on.
@@ -70,11 +76,11 @@ class TargetFileManager:
     """
 
     _base_path = attr.ib(type=Path)
-    _paths = attr.ib(type=List[Path])
+    _all_paths = attr.ib(type=List[Path])
     _ignore_rules_file = attr.ib(type=TextIO)
     _base_commit = attr.ib(type=Optional[str], default=None)
     _status = attr.ib(type=GitStatus, init=False)
-    _target_paths = attr.ib(type=List[Path], init=False)
+    _paths = attr.ib(type=PathLists, init=False)
     _dirty_paths_by_status = attr.ib(type=Dict[str, List[Path]], init=False)
 
     def _fname_to_path(self, repo: "gitpython.Repo", fname: str) -> Path:  # type: ignore
@@ -160,8 +166,8 @@ class TargetFileManager:
 
         return GitStatus(added, modified, removed, unmerged)
 
-    @_target_paths.default
-    def _get_target_files(self) -> List[Path]:
+    @_paths.default
+    def _get_path_lists(self) -> PathLists:
         """
         Return list of all absolute paths to analyze
         """
@@ -172,7 +178,7 @@ class TargetFileManager:
         ]
 
         # resolve given paths relative to current working directory
-        paths = [p.resolve() for p in self._paths]
+        paths = [p.resolve() for p in self._all_paths]
         if self._base_commit is not None:
             paths = [
                 a
@@ -210,21 +216,28 @@ class TargetFileManager:
             f"| found {unit_len(walked_entries, 'file')} in the paths to be scanned",
             err=True,
         )
-        filtered: List[Path] = []
+        survived_paths: List[Path] = []
+        ignored_paths: List[Path] = []
         for elem in walked_entries:
-            if elem.survives:
-                filtered.append(elem.path)
+            paths_group = survived_paths if elem.survives else ignored_paths
+            paths_group.append(elem.path)
 
-        skipped_count = len(walked_entries) - len(filtered)
-        if skipped_count:
+        if ignored_paths:
             click.echo(
-                f"| skipping {unit_len(range(skipped_count), 'file')} based on path ignore rules",
+                f"| skipping {unit_len(ignored_paths, 'file')} based on path ignore rules",
                 err=True,
             )
 
-        relative_paths = [path.relative_to(self._base_path) for path in filtered]
+        relative_survived_paths = [
+            path.relative_to(self._base_path) for path in survived_paths
+        ]
+        relative_ignored_paths = [
+            path.relative_to(self._base_path) for path in ignored_paths
+        ]
 
-        return relative_paths
+        return PathLists(
+            targeted=relative_survived_paths, ignored=relative_ignored_paths
+        )
 
     @_dirty_paths_by_status.default
     def get_dirty_paths_by_status(self) -> Dict[str, List[Path]]:
@@ -359,7 +372,7 @@ class TargetFileManager:
             with self._baseline_context():
                 yield [
                     relative_path
-                    for relative_path in self._target_paths
+                    for relative_path in self._paths.targeted
                     if self._fname_to_path(repo, str(relative_path))
                     not in self._status.added
                 ]
@@ -376,4 +389,13 @@ class TargetFileManager:
         :return: A list of paths
         :raises ActionFailure: If git cannot detect a HEAD commit or unmerged files exist
         """
-        yield self._target_paths
+        yield self._paths.targeted
+
+    @property
+    def ignored_paths(self) -> List[Path]:
+        """
+        Return list of paths that have been ignored.
+
+        :return: A list of paths
+        """
+        return self._paths.ignored

--- a/tests/test_semgrep_app.py
+++ b/tests/test_semgrep_app.py
@@ -54,7 +54,7 @@ def test_no_notification(capfd):
     results = Mock()
     results.findings.new = []
     results.findings.ignored = []
-    results.findings.ignored_paths = []
+    results.findings.searched_paths = []
 
     sapp.report_results(results)
 

--- a/tests/test_semgrep_app.py
+++ b/tests/test_semgrep_app.py
@@ -54,6 +54,7 @@ def test_no_notification(capfd):
     results = Mock()
     results.findings.new = []
     results.findings.ignored = []
+    results.findings.ignored_paths = []
 
     sapp.report_results(results)
 


### PR DESCRIPTION
This is one step toward having a more reliable 'fixed' status

By sending the list of searched paths to the semgrep-app backend, we enable semgrep-app to distinguish between issues that no longer show up because they were _fixed_ and issues that no longer show up because their paths are _ignored_. 

In a future PR we will actually use these data on semgrep-app to change such issues to status "REMOVED" rather than status "FIXED".