### PR TITLE
When run with debug, report --debug output

### DIFF
--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -235,7 +235,7 @@ def invoke_semgrep(
     """
     output: Dict[str, List[Any]] = {"results": [], "errors": []}
 
-    for err_write in debug_file_descriptor():
+    with debug_file_descriptor() as err_write:
         for chunk in chunked_iter(targets, PATHS_CHUNK_SIZE):
             with tempfile.NamedTemporaryFile("w") as output_json_file:
                 args = semgrep_args.copy()

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -1,6 +1,8 @@
+import asyncio
 import io
 import json
 import os
+import sys
 import tempfile
 import time
 from contextlib import contextmanager
@@ -26,7 +28,9 @@ from semgrep_agent.findings import Finding
 from semgrep_agent.findings import FindingSets
 from semgrep_agent.targets import TargetFileManager
 from semgrep_agent.utils import debug_echo
+from semgrep_agent.utils import debug_file_descriptor
 from semgrep_agent.utils import get_git_repo
+from semgrep_agent.utils import is_debug
 from semgrep_agent.utils import print_git_log
 
 ua_environ = {"SEMGREP_USER_AGENT_APPEND": "(Agent)", **os.environ}
@@ -231,26 +235,30 @@ def invoke_semgrep(
     """
     output: Dict[str, List[Any]] = {"results": [], "errors": []}
 
-    for chunk in chunked_iter(targets, PATHS_CHUNK_SIZE):
-        with tempfile.NamedTemporaryFile("w") as output_json_file:
-            args = semgrep_args.copy()
-            args.extend(
-                [
-                    "-o",
-                    output_json_file.name,  # nosem: python.lang.correctness.tempfile.flush.tempfile-without-flush
-                ]
-            )
-            for c in chunk:
-                args.append(c)
+    for err_write in debug_file_descriptor():
+        for chunk in chunked_iter(targets, PATHS_CHUNK_SIZE):
+            with tempfile.NamedTemporaryFile("w") as output_json_file:
+                args = semgrep_args.copy()
+                if is_debug():
+                    args.extend(["--debug"])
+                args.extend(
+                    [
+                        "-o",
+                        output_json_file.name,  # nosem: python.lang.correctness.tempfile.flush.tempfile-without-flush
+                    ]
+                )
+                for c in chunk:
+                    args.append(c)
 
-            _ = semgrep_exec(*(args), _timeout=timeout)
-            with open(
-                output_json_file.name  # nosem: python.lang.correctness.tempfile.flush.tempfile-without-flush
-            ) as f:
-                parsed_output = json.load(f)
+                _ = semgrep_exec(*(args), _timeout=timeout, _err=err_write)
 
-            output["results"].extend(parsed_output["results"])
-            output["errors"].extend(parsed_output["errors"])
+                with open(
+                    output_json_file.name  # nosem: python.lang.correctness.tempfile.flush.tempfile-without-flush
+                ) as f:
+                    parsed_output = json.load(f)
+
+                output["results"].extend(parsed_output["results"])
+                output["errors"].extend(parsed_output["errors"])
 
     return output
 

--- a/src/semgrep_agent/utils.py
+++ b/src/semgrep_agent/utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from textwrap import dedent
 from textwrap import indent
@@ -29,6 +30,7 @@ def is_debug() -> Optional[str]:
     return os.getenv("SEMGREP_AGENT_DEBUG")
 
 
+@contextmanager
 def debug_file_descriptor() -> Iterator[Optional[IO]]:
     if not is_debug():
         yield None

--- a/src/semgrep_agent/utils.py
+++ b/src/semgrep_agent/utils.py
@@ -4,7 +4,10 @@ import sys
 from pathlib import Path
 from textwrap import dedent
 from textwrap import indent
+from threading import Thread
 from typing import cast
+from typing import IO
+from typing import Iterator
 from typing import List
 from typing import NoReturn
 from typing import Optional
@@ -22,9 +25,34 @@ if TYPE_CHECKING:
     from semgrep_agent.meta import GitMeta
 
 
+def is_debug() -> Optional[str]:
+    return os.getenv("SEMGREP_AGENT_DEBUG")
+
+
+def debug_file_descriptor() -> Iterator[Optional[IO]]:
+    if not is_debug():
+        yield None
+    else:
+        read_fd, write_fd = os.pipe()
+
+        def reroute_output() -> None:
+            with open(read_fd) as f:
+                for line in f:
+                    debug_echo(line)
+
+        th = Thread(target=reroute_output)
+        th.start()
+
+        try:
+            with open(write_fd) as err_write:
+                yield err_write
+        finally:
+            th.join()
+
+
 def debug_echo(text: str) -> None:
     """Print debug messages with context-specific debug formatting."""
-    if os.getenv("SEMGREP_AGENT_DEBUG"):
+    if is_debug():
         prefix = "=== [DEBUG] "
     elif os.getenv("GITHUB_ACTIONS"):
         prefix = "::debug::"


### PR DESCRIPTION
If the debug environment variable is set, run `semgrep` with `--debug`. To pass the stderr output of the subprocess through `debug_echo`, `debug_file_descriptor` creates a file descriptor and starts a thread that simply reads the os output, calls `debug_echo` on the line.