### PR TITLE
Send list of semgrep rules run to backend

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -266,8 +266,8 @@ def protected_main(
             click.echo(f"| using semgrep rules from {resolved}", err=True)
         config = resolved_config
     elif sapp.is_configured:
-        local_config_path, num_rules, cai_rules = sapp.download_rules()
-        if num_rules == 0:
+        local_config_path, rule_ids, cai_ids = sapp.download_rules()
+        if len(rule_ids) + len(cai_ids) == 0:
             message = """
             === [ERROR] This policy will not run any rules
 
@@ -283,10 +283,9 @@ def protected_main(
             sys.exit(1)
         config = (str(local_config_path),)
         click.echo(
-            f"| using {num_rules} semgrep rules configured on the web UI", err=True
+            f"| using {len(rule_ids)} semgrep rules configured on the web UI", err=True
         )
-        if cai_rules:
-            click.echo(f"| using {cai_rules} code asset inventory rules")
+        click.echo(f"| using {len(cai_ids)} code asset inventory rules")
     elif Path(".semgrep.yml").is_file():
         click.echo("| using semgrep rules from the committed .semgrep.yml", err=True)
         config = (".semgrep.yml",)
@@ -380,7 +379,7 @@ def protected_main(
         )
 
     if sapp.is_configured:
-        sapp.report_results(results)
+        sapp.report_results(results, rule_ids, cai_ids)
 
     audit_mode = meta.event_name in audit_on
     if blocking_findings and audit_mode:

--- a/tests/test_semgrep_app.py
+++ b/tests/test_semgrep_app.py
@@ -56,7 +56,7 @@ def test_no_notification(capfd):
     results.findings.ignored = []
     results.findings.searched_paths = []
 
-    sapp.report_results(results)
+    sapp.report_results(results, [], [])
 
     # Check Stdout
     out, err = capfd.readouterr()


### PR DESCRIPTION
This small modification to semgrep-agent sends the rule ids that were used in the semgrep scan (downloaded via policies and CAI) to the semgrep-app backend.

I also considered calling rules.yml from the backend itself, but that endpoint is very slow, and we don't actually need the rules' content in the backend, just the rule ids to compare against the rule ids that created our old findings.