### PR TITLE
Add debug logging and timeout to git checkout

### DIFF
--- a/src/semgrep_agent/utils.py
+++ b/src/semgrep_agent/utils.py
@@ -30,28 +30,6 @@ def is_debug() -> Optional[str]:
     return os.getenv("SEMGREP_AGENT_DEBUG")
 
 
-@contextmanager
-def debug_file_descriptor() -> Iterator[Optional[IO]]:
-    if not is_debug():
-        yield None
-    else:
-        read_fd, write_fd = os.pipe()
-
-        def reroute_output() -> None:
-            with open(read_fd) as f:
-                for line in f:
-                    debug_echo(line)
-
-        th = Thread(target=reroute_output)
-        th.start()
-
-        try:
-            with open(write_fd) as err_write:
-                yield err_write
-        finally:
-            th.join()
-
-
 def debug_echo(text: str) -> None:
     """Print debug messages with context-specific debug formatting."""
     if is_debug():


### PR DESCRIPTION
We sometimes see GitHub actions hanging on git checkout. Let's
- prevent a hang here by timing out (will throw an exception,
  causing the agent to crash) after 5 minutes
- add debug logging to show us what's going on

Also use sh's callback functionality to avoid spinning up an auxiliary
thread.