### PR TITLE
specify --json flag via envvar

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -113,7 +113,13 @@ def url(string: str) -> str:
     help="The URL of the Semgrep app",
     hidden=True,
 )
-@click.option("--json", "json_output", hidden=True, is_flag=True)
+@click.option(
+    "--json",
+    "json_output",
+    envvar="SEMGREP_JSON_OUTPUT",
+    hidden=True,
+    is_flag=True
+)
 @click.option(
     "--gitlab-json",
     "gitlab_output",

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -114,11 +114,7 @@ def url(string: str) -> str:
     hidden=True,
 )
 @click.option(
-    "--json",
-    "json_output",
-    envvar="SEMGREP_JSON_OUTPUT",
-    hidden=True,
-    is_flag=True
+    "--json", "json_output", envvar="SEMGREP_JSON_OUTPUT", hidden=True, is_flag=True
 )
 @click.option(
     "--gitlab-json",


### PR DESCRIPTION
Hi there,

My use case for semgrep-action in GitHub Actions requires post-processing on the agent's output, ideally in JSON format. However the `--json` flag cannot be specified through the inputs defined in action.yml or an environment variable. This small PR allows specifying the flag through the `SEMGREP_JSON_OUTPUT` envvar.

Please let me know if there's anything I can change. Cheers!