### PR TITLE
Add timeouts to all shell processes

### DIFF
--- a/src/semgrep_agent/meta.py
+++ b/src/semgrep_agent/meta.py
@@ -189,8 +189,10 @@ class GithubMeta(GitMeta):
             debug_echo(
                 f"fetching {fetch_depth} commits to find branch-off point of pull request"
             )
-            git.fetch("origin", "--depth", fetch_depth, self.base_branch_tip)
-            git.fetch("origin", "--depth", fetch_depth, self.head_ref)
+            git.fetch(
+                "origin", "--depth", fetch_depth, self.base_branch_tip, _timeout=60
+            )
+            git.fetch("origin", "--depth", fetch_depth, self.head_ref, _timeout=60)
 
         try:  # check if both branches connect to the yet-unknown branch-off point now
             process = git("merge-base", self.base_branch_tip, self.head_ref)
@@ -309,7 +311,7 @@ class GitlabMeta(GitMeta):
         if not target_branch:
             return None
         head_sha = git("rev-parse", "HEAD").stdout.strip()
-        git.fetch(self._get_remote_url(), target_branch)
+        git.fetch(self._get_remote_url(), target_branch, _timeout=60)
         base_sha = (
             git("merge-base", "--all", head_sha, "FETCH_HEAD").stdout.decode().strip()
         )

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -376,7 +376,7 @@ def _fix_head_for_github(
         if not stashed_rev:
             stashed_rev = git(["rev-parse", "HEAD"]).stdout.decode("utf-8").rstrip()
         click.echo(f"| not on head ref {head_ref}; checking that out now...", err=True)
-        git.checkout([head_ref], _timeout=300, _out=debug_echo, _err=debug_echo)
+        git.checkout([head_ref], _timeout=60, _out=debug_echo, _err=debug_echo)
         debug_echo(f"checked out {head_ref}")
 
     try:
@@ -396,4 +396,4 @@ def _fix_head_for_github(
     finally:
         if stashed_rev is not None:
             click.echo(f"| returning to original head revision {stashed_rev}", err=True)
-            git.checkout([stashed_rev])
+            git.checkout([stashed_rev], _timeout=60)

--- a/src/semgrep_agent/targets.py
+++ b/src/semgrep_agent/targets.py
@@ -115,6 +115,7 @@ class TargetFileManager:
                 "--diff-filter=ACDMRTUXB",
                 "--ignore-submodules",
                 self._base_commit,
+                _timeout=60,
             ).stdout.decode()
         )
 
@@ -249,7 +250,7 @@ class TargetFileManager:
 
         These can be staged, unstaged, or untracked.
         """
-        output = zsplit(git.status("--porcelain", "-z").stdout.decode())
+        output = zsplit(git.status("--porcelain", "-z", _timeout=60).stdout.decode())
         return bucketize(
             output,
             key=lambda line: line[0],
@@ -320,7 +321,7 @@ class TargetFileManager:
                     a.unlink()
                 except FileNotFoundError:
                     click.echo(f"| {a} was not found when trying to delete", err=True)
-            git.checkout(self._base_commit, "--", ".")
+            git.checkout(self._base_commit, "--", ".", _timeout=60)
             yield
         finally:
             # git checkout will fail if the checked-out index deletes all files in the repo
@@ -328,7 +329,7 @@ class TargetFileManager:
             # Note that we have no good way of detecting this issue without inspecting the checkout output
             # message, which means we are fragile with respect to git version here.
             try:
-                git.checkout(current_tree.strip(), "--", ".")
+                git.checkout(current_tree.strip(), "--", ".", _timeout=60)
             except sh.ErrorReturnCode as error:
                 output = error.stderr.decode()
                 if (
@@ -350,7 +351,7 @@ class TargetFileManager:
                 # in both the base and head. Only call if there are files to delete
                 to_remove = [r for r in self._status.removed if r.exists()]
                 if to_remove:
-                    git.rm("-f", *(str(r) for r in to_remove))
+                    git.rm("-f", *(str(r) for r in to_remove), _timeout=60)
 
     @contextmanager
     def baseline_paths(self) -> Iterator[List[Path]]:

--- a/src/semgrep_agent/utils.py
+++ b/src/semgrep_agent/utils.py
@@ -78,7 +78,7 @@ def validate_publish_token(token: str) -> bool:
 
 
 def print_git_log(log_cmd: str) -> None:
-    log = git.log(["--oneline", "--graph", log_cmd]).stdout  # type:ignore
+    log = git.log(["--oneline", "--graph", log_cmd], _timeout=60).stdout  # type:ignore
     rr = cast(bytes, log).decode("utf-8").rstrip().split("\n")
     r = "\n|   ".join(rr)
     click.echo("|   " + r, err=True)


### PR DESCRIPTION
In GHA, we sporadically see the action hang for up to 6 hours on
subshells. Call all subshells with a _timeout flag to early abort. In
the future, we can add retries in this case.