### PR TITLE
Print and report semgrep errors

### DIFF
--- a/src/semgrep_agent/constants.py
+++ b/src/semgrep_agent/constants.py
@@ -6,3 +6,7 @@ SUPPORT_EMAIL = "support@r2c.dev"
 PRIVACY_SENSITIVE_FIELDS = {"syntactic_context", "fixed_lines"}
 
 PUBLISH_TOKEN_VALIDATOR = re.compile(r"\w{64,}")
+
+ERROR_EXIT_CODE = 2
+FINDING_EXIT_CODE = 1
+NO_RESULT_EXIT_CODE = 0

--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -14,6 +14,7 @@ from typing import List
 from typing import Mapping
 from typing import NamedTuple
 from typing import Optional
+from typing import Sequence
 from typing import Set
 
 import attr
@@ -210,10 +211,12 @@ class FindingSet(Set[Finding]):
 
 @dataclass(frozen=True)
 class FindingSets:
+    exit_code: int = field()
     baseline: FindingSet = field(default_factory=FindingSet)
     current: FindingSet = field(default_factory=FindingSet)
     ignored: FindingSet = field(default_factory=FindingSet)
     searched_paths: Set[Path] = field(default_factory=set)
+    errors: Sequence[Mapping[str, Any]] = field(default_factory=list)
 
     @property
     def new(self) -> Set[Finding]:

--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -211,7 +211,8 @@ class FindingSet(Set[Finding]):
 
 @dataclass(frozen=True)
 class FindingSets:
-    exit_code: int = field()
+    # 2 if semgrep has errors, otherwise 1 if semgrep has findings, otherwise 0
+    max_exit_code: int = field()
     baseline: FindingSet = field(default_factory=FindingSet)
     current: FindingSet = field(default_factory=FindingSet)
     ignored: FindingSet = field(default_factory=FindingSet)

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -15,6 +15,9 @@ from git import InvalidGitRepositoryError
 
 from semgrep_agent import formatter
 from semgrep_agent import semgrep
+from semgrep_agent.constants import ERROR_EXIT_CODE
+from semgrep_agent.constants import FINDING_EXIT_CODE
+from semgrep_agent.constants import NO_RESULT_EXIT_CODE
 from semgrep_agent.exc import ActionFailure
 from semgrep_agent.meta import generate_meta_from_environment
 from semgrep_agent.meta import GithubMeta
@@ -396,7 +399,17 @@ def protected_main(
             f"| to see your findings in the app, go to {publish_url}/manage/findings?repo={meta.repo_name}"
         )
 
-    exit_code = 0 if audit_mode else (2 if errors else 1 if blocking_findings else 0)
+    exit_code = (
+        NO_RESULT_EXIT_CODE
+        if audit_mode
+        else (
+            ERROR_EXIT_CODE
+            if errors
+            else FINDING_EXIT_CODE
+            if blocking_findings
+            else NO_RESULT_EXIT_CODE
+        )
+    )
     click.echo(
         f"=== exiting with {'failing' if exit_code == 1 else 'success'} status",
         err=True,

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -352,6 +352,7 @@ def protected_main(
     )
 
     new_findings = results.findings.new
+    errors = results.findings.errors
 
     blocking_findings = {finding for finding in new_findings if finding.is_blocking()}
 
@@ -395,7 +396,7 @@ def protected_main(
             f"| to see your findings in the app, go to {publish_url}/manage/findings?repo={meta.repo_name}"
         )
 
-    exit_code = 1 if blocking_findings and not audit_mode else 0
+    exit_code = 0 if audit_mode else (2 if errors else 1 if blocking_findings else 0)
     click.echo(
         f"=== exiting with {'failing' if exit_code == 1 else 'success'} status",
         err=True,

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -13,9 +13,11 @@ from typing import Any
 from typing import Dict
 from typing import Iterator
 from typing import List
+from typing import Mapping
 from typing import Optional
 from typing import Sequence
 from typing import TextIO
+from typing import Tuple
 
 import click
 import sh
@@ -31,6 +33,7 @@ from semgrep_agent.utils import debug_echo
 from semgrep_agent.utils import get_git_repo
 from semgrep_agent.utils import is_debug
 from semgrep_agent.utils import print_git_log
+from semgrep_agent.utils import render_error
 
 ua_environ = {"SEMGREP_USER_AGENT_APPEND": "(Agent)", **os.environ}
 semgrep_exec = sh.semgrep.bake(_ok_code={0, 1}, _tty_out=False, _env=ua_environ)
@@ -82,6 +85,7 @@ class Results:
     def stats(self) -> Dict[str, Any]:
         return {
             "findings": len(self.findings.new),
+            "errors": len(self.findings.errors),
             "total_time": self.total_time,
         }
 
@@ -134,7 +138,6 @@ def get_findings(
         rewrite_args = [] if rewrite_rule_ids else ["--no-rewrite-rule-ids"]
         metrics_args = ["--enable-metrics"] if enable_metrics else []
         debug_echo("=== seeing if there are any findings")
-        findings = FindingSets(searched_paths=set(targets.searched_paths))
 
         with targets.current_paths() as paths:
             click.echo(
@@ -154,9 +157,16 @@ def get_findings(
                 *rewrite_args,
                 *config_args,
             ]
-            semgrep_results = invoke_semgrep(
+            exit_code, semgrep_output = invoke_semgrep(
                 args, [str(p) for p in paths], timeout=timeout
-            )["results"]
+            )
+            findings = FindingSets(
+                exit_code,
+                searched_paths=set(targets.searched_paths),
+                errors=semgrep_output.get("errors", []),
+            )
+
+            semgrep_results = semgrep_output["results"]
 
             findings.current.update_findings(
                 Finding.from_semgrep_result(result, committed_datetime)
@@ -168,6 +178,14 @@ def get_findings(
                 for result in semgrep_results
                 if result["extra"].get("is_ignored")
             )
+            if findings.errors:
+                click.echo(
+                    f"| Semgrep exited with {unit_len(findings.errors, 'error')}:",
+                    err=True,
+                )
+                for e in findings.errors:
+                    for s in render_error(e):
+                        click.echo(f"|    {s}", err=True)
             click.echo(
                 f"| {unit_len(findings.current, 'current issue')} found", err=True
             )
@@ -224,9 +242,8 @@ def get_findings(
                         *rewrite_args,
                         *config_args,
                     ]
-                    semgrep_results = invoke_semgrep(
-                        args, paths_to_check, timeout=timeout
-                    )["results"]
+                    _, sr = invoke_semgrep(args, paths_to_check, timeout=timeout)
+                    semgrep_results = sr["results"]
                     findings.baseline.update_findings(
                         Finding.from_semgrep_result(result, committed_datetime)
                         for result in semgrep_results
@@ -252,13 +269,15 @@ def get_findings(
 
 def invoke_semgrep(
     semgrep_args: List[str], targets: List[str], *, timeout: Optional[int]
-) -> Dict[str, List[Any]]:
+) -> Tuple[int, Mapping[str, List[Any]]]:
     """
     Call semgrep passing in semgrep_args + targets as the arguments
 
     Returns json output of semgrep as dict object
     """
     output: Dict[str, List[Any]] = {"results": [], "errors": []}
+
+    max_exit_code = 0
 
     for chunk in chunked_iter(targets, PATHS_CHUNK_SIZE):
         with tempfile.NamedTemporaryFile("w") as output_json_file:
@@ -274,7 +293,8 @@ def invoke_semgrep(
             for c in chunk:
                 args.append(c)
 
-            _ = semgrep_exec(*args, _timeout=timeout, _err=debug_echo)
+            exit_code = semgrep_exec(*args, _timeout=timeout, _err=debug_echo).exit_code
+            max_exit_code = max(max_exit_code, exit_code)
 
             with open(
                 output_json_file.name  # nosem: python.lang.correctness.tempfile.flush.tempfile-without-flush
@@ -284,7 +304,7 @@ def invoke_semgrep(
             output["results"].extend(parsed_output["results"])
             output["errors"].extend(parsed_output["errors"])
 
-    return output
+    return max_exit_code, output
 
 
 class SemgrepError(Exception):

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -85,7 +85,7 @@ class Results:
     def stats(self) -> Dict[str, Any]:
         return {
             "findings": len(self.findings.new),
-            "errors": len(self.findings.errors),
+            "errors": self.findings.errors,
             "total_time": self.total_time,
         }
 

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -182,8 +182,6 @@ class Sapp:
         if "pr-comment-autofix" in os.getenv("SEMGREP_AGENT_OPT_IN_FEATURES", ""):
             fields_to_omit.remove("fixed_lines")
 
-        response: Optional["requests.Response"] = None
-
         response = self.session.post(
             f"{self.url}/api/agent/scan/{self.scan.id}/findings",
             json={
@@ -228,7 +226,11 @@ class Sapp:
         # mark as complete
         response = self.session.post(
             f"{self.url}/api/agent/scan/{self.scan.id}/complete",
-            json={"exit_code": -1, "stats": results.stats},
+            json={
+                "exit_code": results.findings.exit_code,
+                "stats": results.stats,
+                "errors": results.findings.errors,
+            },
             timeout=30,
         )
         debug_echo(f"=== POST .../complete responded: {response!r}")

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -229,7 +229,6 @@ class Sapp:
             json={
                 "exit_code": results.findings.exit_code,
                 "stats": results.stats,
-                "errors": results.findings.errors,
             },
             timeout=30,
         )

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -227,7 +227,7 @@ class Sapp:
         response = self.session.post(
             f"{self.url}/api/agent/scan/{self.scan.id}/complete",
             json={
-                "exit_code": results.findings.exit_code,
+                "exit_code": results.findings.max_exit_code,
                 "stats": results.stats,
             },
             timeout=30,

--- a/src/semgrep_agent/utils.py
+++ b/src/semgrep_agent/utils.py
@@ -6,12 +6,15 @@ from pathlib import Path
 from textwrap import dedent
 from textwrap import indent
 from threading import Thread
+from typing import Any
 from typing import cast
 from typing import IO
 from typing import Iterator
 from typing import List
+from typing import Mapping
 from typing import NoReturn
 from typing import Optional
+from typing import Sequence
 from typing import TYPE_CHECKING
 
 import click
@@ -50,6 +53,14 @@ def maybe_print_debug_info(meta: "GitMeta") -> None:
     debug_echo(json.dumps(ecoutils.get_profile(), indent=2, sort_keys=True))
     debug_echo("\n== meta info:")
     debug_echo(json.dumps(meta.to_dict(), indent=2, sort_keys=True))
+
+
+def render_error(error: Mapping[str, Any]) -> Sequence[str]:
+    spans = error.get("spans")
+    msg = error.get("long_msg", "")
+    if spans:
+        return [f"{s['file']}:{s['start']['line']} {msg}" for s in spans]
+    return [msg]
 
 
 def get_git_repo(path: Optional[Path] = None) -> Optional[gitpython.Repo]:  # type: ignore


### PR DESCRIPTION
Previously, we just ate our errors :(. Instead, let's surface them to
users AND upload them to our backend.

Also report correct exit code.