### PR TITLE
Run semgrep with debug

### DIFF
--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -283,8 +283,7 @@ def invoke_semgrep(
     for chunk in chunked_iter(targets, PATHS_CHUNK_SIZE):
         with tempfile.NamedTemporaryFile("w") as output_json_file:
             args = semgrep_args.copy()
-            if is_debug():
-                args.extend(["--debug"])
+            args.extend(["--debug"])
             args.extend(
                 [
                     "-o",


### PR DESCRIPTION
The stderr of semgrep is conditionally printed by debug_echo which is controlled by env variable or github secret. No need to have a different env var also control whether or not to even run with debugging.