### PR TITLE
Prevent semgrep output from breaking sarif output

### DIFF
--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -251,7 +251,6 @@ def get_findings(
                     )
 
     if os.getenv("INPUT_GENERATESARIF"):
-        # FIXME: This will crash when running on thousands of files due to command length limit
         click.echo("=== re-running scan to generate a SARIF report", err=True)
         sarif_path = Path("semgrep.sarif")
         with targets.current_paths() as paths:

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -259,7 +259,7 @@ def get_findings(
         click.echo("=== re-running scan to generate a SARIF report", err=True)
         sarif_path = Path("semgrep.sarif")
         with targets.current_paths() as paths, sarif_path.open("w") as sarif_file:
-            args = ["--sarif", *rewrite_args, *config_args]
+            args = ["--quiet", "--sarif", *rewrite_args, *config_args]
             for path in paths:
                 args.extend(["--include", str(path)])
             semgrep_exec(*args, _out=sarif_file, _timeout=timeout)


### PR DESCRIPTION
This should solve https://github.com/returntocorp/semgrep-action/issues/346 I think the issue is that semgrep is printing out non sarif logging code.