### PR TITLE
Remove publishDeployment part 2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,5 @@ jobs:
       - uses: returntocorp/semgrep-action@v1
         with:
           publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
-          publishDeployment: "1"
         env:
           SEMGREP_AGENT_DEBUG: 1


### PR DESCRIPTION
We can remove publishDeployment from our own semgrep file now that it isn't needed anymore