### PR TITLE
trying out an experiment to neverFail

### DIFF
--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -1,18 +1,19 @@
+import hashlib
+import hmac
 import json
 import os
 import tempfile
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
+from typing import Any
 from typing import cast
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
 
-import click
 import requests
-from glom import glom
-from glom import T
 from urllib3.util.retry import Retry
 
 from semgrep_agent import constants
@@ -45,8 +46,11 @@ class Scan:
 class Sapp:
     url: str
     token: str
-    deployment_id: Optional[int] = None
-    deployment_name: Optional[str] = None
+    org_id: Optional[int] = None
+    org_name: Optional[str] = None
+    rules_str: Optional[str] = None
+    policy: Optional[Dict[str, Any]] = None
+    meta: Optional[GitMeta] = None
     scan: Scan = Scan()
     is_configured: bool = False
     session: requests.Session = field(init=False)
@@ -57,18 +61,20 @@ class Sapp:
 
             self.session = requests.Session()
             self.session.mount("https://", RETRYING_ADAPTER)
-            self.session.headers["Authorization"] = f"Bearer {self.token}"
+            # self.session.headers["Authorization"] = f"Bearer {self.token}"
 
             if validate_token_length(self.token):
-                self.get_deployment_from_token(self.token)
+                self.get_org_config_from_token(self.token)
             else:
                 raise ActionFailure(
                     f"Received invalid publish token. Length is too short."
                 )
 
-    def get_deployment_from_token(self, token: str) -> None:
+    def get_org_config_from_token(self, token: str) -> None:
+        # TODO change this to the Semgrep Registry and clean up the format
+        url = "https://gist.githubusercontent.com/DrewDennison/b9934d2927dbb64928466d5af815aefd/raw/a9e77e75709606f32cfb6b2e7adfd20db4047b47/DrewDennison.json"
         response = self.session.get(
-            f"{self.url}/api/agent/deployment",
+            url,
             json={},
             timeout=30,
         )
@@ -76,90 +82,44 @@ class Sapp:
             response.raise_for_status()
         except requests.RequestException:
             raise ActionFailure(
-                f"API server at {self.url} returned this error: {response.text}\n"
-                "Failed to get deployment"
+                f"API server at {url} returned this error: {response.text}\n"
+                "Failed to get org config"
             )
         data = response.json()
-        self.deployment_id = data.get("deployment").get("id")
-        self.deployment_name = data.get("deployment").get("name")
+        self.org_id = data.get("org").get("id")
+        self.org_name = data.get("org").get("name")
+        self.policy = data.get("policy")
+        self.rules_str = data.get("rules_str")
 
-    def fail_open_exit_code(self, meta: GitMeta, exit_code: int) -> int:
-        response = self.session.get(
-            f"{self.url}/api/agent/deployment/{self.deployment_id}/repos/{meta.repo_name}",
-            json={},
-            timeout=30,
-        )
-        repo_data = response.json()
-        fail_open = repo_data.get("repo").get("fail_open")
-        return 0 if fail_open else exit_code
+    def wrap_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        payload_str = json.dumps(payload)
+        hmac_signature = hmac.new(
+            self.token.encode(), payload_str.encode(), hashlib.sha256
+        ).hexdigest()
+        return {"signature": hmac_signature, "payload": payload}
 
-    def report_start(self, meta: GitMeta) -> str:
-        """
-        Get scan id and file ignores
-
-        returns name of policy used to scan
-        """
-        debug_echo(f"=== reporting start to semgrep app at {self.url}")
-
-        response = self.session.post(
-            f"{self.url}/api/agent/deployment/{self.deployment_id}/scan",
-            json={"meta": meta.to_dict()},
-            timeout=30,
-        )
-
-        debug_echo(f"=== POST .../scan responded: {response!r}")
-
-        if response.status_code == 404:
-            raise ActionFailure(
-                "Failed to create a scan with given token and deployment_id."
-                "Please make sure they have been set correctly."
-                f"API server at {self.url} returned this response: {response.text}"
-            )
-
-        try:
-            response.raise_for_status()
-        except requests.RequestException:
-            raise ActionFailure(
-                f"API server at {self.url} returned this error: {response.text}"
-            )
-        else:
-            body = response.json()
-            self.scan = Scan(
-                id=glom(body, T["scan"]["id"]),
-                ignore_patterns=glom(body, T["scan"]["meta"].get("ignored_files", [])),
-            )
-            debug_echo(f"=== Our scan object is: {self.scan!r}")
-            return cast(str, glom(body, T["policy"]))
-
-    def fetch_rules_text(self) -> str:
+    def validate_rules(self) -> str:
         """Get a YAML string with the configured semgrep rules in it."""
-        response = self.session.get(
-            f"{self.url}/api/agent/scan/{self.scan.id}/rules.yaml",
-            timeout=30,
-        )
-        debug_echo(f"=== POST .../rules.yaml responded: {response!r}")
-
-        try:
-            response.raise_for_status()
-        except requests.RequestException:
-            raise ActionFailure(
-                f"API server at {self.url} returned this error: {response.text}\n"
-                "Failed to get configured rules"
-            )
-
-        # Can remove once server guarantees will always have at least one rule
-        parsed = yaml.load(response.text)
+        if self.rules_str is None:
+            raise ActionFailure("No rules returned by server for this scan.")
+        parsed = yaml.load(self.rules_str)
         if not parsed["rules"]:
             raise ActionFailure("No rules returned by server for this scan.")
         else:
-            return response.text
+            return self.rules_str
+
+    def fail_open_exit_code(self, meta: GitMeta, exit_code: int) -> int:
+        policy = self.policy or {}
+        default_fail_open = policy.get("defaults", {}).get("fail_open", True)
+        fail_open = policy.get("repos", {}).get(meta.repo_name, default_fail_open)
+        return 0 if fail_open else exit_code
 
     def download_rules(self) -> Tuple[Path, List[str], List[str]]:
         """Save the rules configured on semgrep app to a temporary file"""
         # hey, it's just a tiny YAML file in CI, we'll survive without cleanup
         rules_file = tempfile.NamedTemporaryFile(suffix=".yml", delete=False)  # nosem
         rules_path = Path(rules_file.name)  # nosem
-        rules = self.fetch_rules_text()
+        rules = self.validate_rules()
         parsed = yaml.load(rules)
         rules_path.write_text(rules)
         rule_ids = [
@@ -168,96 +128,67 @@ class Sapp:
         cai_ids = [r["id"] for r in parsed["rules"] if "r2c-internal-cai" in r["id"]]
         return rules_path, rule_ids, cai_ids
 
-    def report_failure(self, stderr: str, exit_code: int) -> int:
-        """
-        Send semgrep cli non-zero exit code information to server
-        and return what exit code semgrep should exit with.
-        """
-        debug_echo(f"=== sending failure information to semgrep app")
+    def report_start(self, meta: GitMeta) -> str:
+        self.meta = meta
+        return (self.policy or {}).get("name", "no policy")
 
+    def report_failure(self, stderr: str) -> int:
+        # TODO give this a nice domain like collector.semgrep.dev/v1/failure etc
+        url = "https://11hnyozw6a.execute-api.us-west-2.amazonaws.com/prod/v1/upload"
+        debug_echo(f"=== reporting failure to semgrep app at {url}")
+        payload = {
+            "org": {"id": self.org_id, "name": self.org_name},
+            "meta": self.meta.to_dict() if self.meta else None,
+            "stderr": stderr,
+        }
         response = self.session.post(
-            f"{self.url}/api/agent/scan/{self.scan.id}/error",
-            json={
-                "exit_code": exit_code,
-                "stderr": stderr,
-            },
+            url,
+            json=self.wrap_payload(payload),
             timeout=30,
         )
-
-        debug_echo(f"=== POST .../error responded: {response!r}")
+        debug_echo(f"=== POST .../upload responded: {response!r}")
         try:
             response.raise_for_status()
+
         except requests.RequestException:
             raise ActionFailure(f"API server returned this error: {response.text}")
 
-        exit_code = int(response.json()["exit_code"])
-        return exit_code
+        return 0
 
     def report_results(
         self, results: Results, rule_ids: List[str], cai_ids: List[str]
     ) -> None:
-        debug_echo(f"=== reporting results to semgrep app at {self.url}")
+        # TODO give this a nice domain like collector.semgrep.dev/v1/finding etc
+        url = "https://11hnyozw6a.execute-api.us-west-2.amazonaws.com/prod/v1/upload"
+        debug_echo(f"=== reporting results to semgrep app at {url}")
 
         fields_to_omit = constants.PRIVACY_SENSITIVE_FIELDS.copy()
 
         if "pr-comment-autofix" in os.getenv("SEMGREP_AGENT_OPT_IN_FEATURES", ""):
             fields_to_omit.remove("fixed_lines")
-
-        response = self.session.post(
-            f"{self.url}/api/agent/scan/{self.scan.id}/findings",
-            json={
-                # send a backup token in case the app is not available
-                "token": os.getenv("GITHUB_TOKEN"),
-                "gitlab_token": os.getenv("GITLAB_TOKEN"),
-                "findings": [
-                    finding.to_dict(omit=fields_to_omit)
-                    for finding in results.findings.new
-                ],
-                "searched_paths": [str(p) for p in results.findings.searched_paths],
-                "rule_ids": rule_ids,
-                "cai_ids": cai_ids,
-            },
-            timeout=30,
-        )
-        debug_echo(f"=== POST .../findings responded: {response!r}")
-        try:
-            response.raise_for_status()
-
-            errors = response.json()["errors"]
-            for error in errors:
-                message = error["message"]
-                click.echo(f"Server returned following warning: {message}", err=True)
-
-        except requests.RequestException:
-            raise ActionFailure(f"API server returned this error: {response.text}")
-
-        response = self.session.post(
-            f"{self.url}/api/agent/scan/{self.scan.id}/ignores",
-            json={
-                "findings": [finding.to_dict() for finding in results.findings.ignored],
-            },
-            timeout=30,
-        )
-        debug_echo(f"=== POST .../ignores responded: {response!r}")
-        try:
-            response.raise_for_status()
-        except requests.RequestException:
-            raise ActionFailure(f"API server returned this error: {response.text}")
-
-        # mark as complete
-        response = self.session.post(
-            f"{self.url}/api/agent/scan/{self.scan.id}/complete",
-            json={
+        payload = {
+            "org": {"id": self.org_id, "name": self.org_name},
+            "meta": self.meta.to_dict() if self.meta else None,
+            "findings": [
+                finding.to_dict(omit=fields_to_omit) for finding in results.findings.new
+            ],
+            "ignores": [finding.to_dict() for finding in results.findings.ignored],
+            "searched_paths": [str(p) for p in results.findings.searched_paths],
+            "rule_ids": rule_ids,
+            "cai_ids": cai_ids,
+            "scan": {
                 "exit_code": results.findings.max_exit_code,
                 "stats": results.stats,
             },
+        }
+        response = self.session.post(
+            url,
+            json=self.wrap_payload(payload),
             timeout=30,
         )
-        debug_echo(f"=== POST .../complete responded: {response!r}")
-
+        debug_echo(f"=== POST .../upload responded: {response!r}")
         try:
             response.raise_for_status()
+
         except requests.RequestException:
-            raise ActionFailure(
-                f"API server at {self.url} returned this error: {response.text}"
-            )
+            raise ActionFailure(f"API server returned this error: {response.text}")

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -48,6 +48,7 @@ class Sapp:
     token: str
     org_id: Optional[int] = None
     org_name: Optional[str] = None
+    deployment_name: Optional[str] = None  # legacy
     rules_str: Optional[str] = None
     policy: Optional[Dict[str, Any]] = None
     meta: Optional[GitMeta] = None
@@ -88,6 +89,7 @@ class Sapp:
         data = response.json()
         self.org_id = data.get("org").get("id")
         self.org_name = data.get("org").get("name")
+        self.deployment_name = self.org_name  # legacy
         self.policy = data.get("policy")
         self.rules_str = data.get("rules_str")
 
@@ -132,7 +134,7 @@ class Sapp:
         self.meta = meta
         return (self.policy or {}).get("name", "no policy")
 
-    def report_failure(self, stderr: str) -> int:
+    def report_failure(self, stderr: str, exit_code: int) -> int:
         # TODO give this a nice domain like collector.semgrep.dev/v1/failure etc
         url = "https://11hnyozw6a.execute-api.us-west-2.amazonaws.com/prod/v1/upload"
         debug_echo(f"=== reporting failure to semgrep app at {url}")
@@ -153,7 +155,7 @@ class Sapp:
         except requests.RequestException:
             raise ActionFailure(f"API server returned this error: {response.text}")
 
-        return 0
+        return exit_code  # should this be returned here or just return 0?
 
     def report_results(
         self, results: Results, rule_ids: List[str], cai_ids: List[str]


### PR DESCRIPTION
Instead of making multiple round trips to the server which can go down, try to make one GET to download the org's config and 1 POST with all the findings / failures.

Very very rough proof of concept downloading from a gist and uploading to an endpoint that drops on an SQS queue via a API gateway. All managed AWS things with very high uptime. Semgrep.dev can be completely down and this would still work, not break CI, correctly block the build, and have the results waiting for semgrep.dev when the app cames back online.  

Idea is to have a single org-wide config that contains all the info to block, fail_open, overrides etc. and then serialize so it can be added to the CDN registry. Downtime should come at org config edit -> publish not download when in a CI run. 

![image](https://user-images.githubusercontent.com/1011067/133749175-6df331df-9050-4d20-bdb0-c5eb35627fcf.png)

![0FE834D4-F401-4341-B379-6E30B20EDBD0](https://user-images.githubusercontent.com/1011067/133754799-39ed4b19-d34c-4a30-8ab1-cfebe04bf2ee.jpeg)


![image](https://user-images.githubusercontent.com/1011067/133747038-6667a3db-0bc3-4519-a058-a39110278c9c.png)

![977C21CB-6888-4A58-B330-448547CD14BD](https://user-images.githubusercontent.com/1011067/133752621-324ff721-0d7b-46e1-bcf2-0243c53894bf.jpeg)

note the methods and dataclasses in semgrep_app.py are still not optimized but I didn’t want to modify any other files
