### PR TITLE
Semgrep-action output message clarifications

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -334,7 +334,6 @@ def protected_main(
     errors = results.findings.errors
 
     blocking_findings = {finding for finding in new_findings if finding.is_blocking()}
-
     if json_output:
         # Output all new findings as json
         json_contents = [f.to_dict(omit=set()) for f in new_findings]
@@ -357,7 +356,7 @@ def protected_main(
     if non_blocking_findings:
         inventory_findings_len = 0
         for finding in non_blocking_findings:
-            if finding.is_cai_finding:
+            if finding.is_cai_finding():
                 inventory_findings_len += 1
         click.echo(
             f"| {unit_len(range(len(non_blocking_findings)-inventory_findings_len), 'non-blocking finding')} hidden in output",

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -198,7 +198,7 @@ def get_findings(
                 err=True,
             )
             click.echo(
-                f"| {unit_len(findings.ignored, 'ignored issue')} found",
+                f"| {unit_len(findings.ignored, 'issue')} muted with nosemgrep comment",
                 err=True,
             )
 

--- a/tests/acceptance/baseline-generic/new-agent.err
+++ b/tests/acceptance/baseline-generic/new-agent.err
@@ -10,6 +10,6 @@
 | found 1 file in the paths to be scanned
 === looking for current issues in 1 file
 | 1 current issue found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/baseline-local-file/new-agent.err
+++ b/tests/acceptance/baseline-local-file/new-agent.err
@@ -10,7 +10,7 @@
 | found 2 files in the paths to be scanned
 === looking for current issues in 2 files
 | 1 current issue found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === .semgrep.yml file not found in baseline, skipping scanning for baseline
 === not looking at pre-exiting issues since after filtering out local files that don't exist in baseline, no configs left to run
 === exiting with failing status

--- a/tests/acceptance/disconnected-generic/disconnected-agent.err
+++ b/tests/acceptance/disconnected-generic/disconnected-agent.err
@@ -9,6 +9,6 @@
 | skipping 1 file based on path ignore rules
 === looking for current issues in 1 file
 | 1 current issue found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/mergebase-generic/new-agent.err
+++ b/tests/acceptance/mergebase-generic/new-agent.err
@@ -14,6 +14,6 @@
 | found 2 files in the paths to be scanned
 === looking for current issues in 2 files
 | 2 current issues found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/multiconfig-generic/new-agent.err
+++ b/tests/acceptance/multiconfig-generic/new-agent.err
@@ -11,6 +11,6 @@
 | found 1 file in the paths to be scanned
 === looking for current issues in 1 file
 | 1 current issue found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/push-generic/push-agent.err
+++ b/tests/acceptance/push-generic/push-agent.err
@@ -9,6 +9,6 @@
 | skipping 1 file based on path ignore rules
 === looking for current issues in 1 file
 | 1 current issue found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/semgrep-rules-repo/local-config-full-scan.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-full-scan.err
@@ -9,6 +9,6 @@
 | skipping 3 files based on path ignore rules
 === looking for current issues in 1473 files
 | 2 current issues found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/semgrep-rules-repo/local-config-no-new-results.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-no-new-results.err
@@ -10,6 +10,6 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | No current issues found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since there are no current issues
 === exiting with success status

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-audit-mode.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-audit-mode.err
@@ -10,7 +10,7 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | 2 current issues found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 | audit mode is on for unknown, so the findings won't cause failure
 === exiting with success status

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-github-env-json.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-github-env-json.err
@@ -10,6 +10,6 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | 2 current issues found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-gitlab-env-json.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-gitlab-env-json.err
@@ -10,6 +10,6 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | 2 current issues found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-gitlab-json.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-gitlab-json.err
@@ -10,6 +10,6 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | 2 current issues found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-json.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-json.err
@@ -10,6 +10,6 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | 2 current issues found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results.err
@@ -10,6 +10,6 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | 2 current issues found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/symlink-dir/new-agent.err
+++ b/tests/acceptance/symlink-dir/new-agent.err
@@ -11,6 +11,6 @@
 | found No files in the paths to be scanned
 === looking for current issues in No files
 | No current issues found
-| No ignored issues found
+| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since there are no current issues
 === exiting with success status


### PR DESCRIPTION
- we previously were checking for existence of a function, rather than checking the boolean value returned by that function, leading to us always thinking non-blocking findings were CAI findings

- [x] Write a semgrep rule for this https://github.com/returntocorp/semgrep-rules/pull/1490/files 

- the term "ignored" has confused users who are now using the triaging flow. Ignored can be used to refer to developer-muted (with inline comment) or appsec-muted (with triage flow). Let's be more specific here about which we are referring to.

### Security

- [ ] Change has security implications (if so, ping the security team)
