### PR TITLE
Add support for GitHub annotations as formatter output

### DIFF
--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -133,6 +133,24 @@ class Finding:
         d["is_blocking"] = self.is_blocking()
         return d
 
+    def to_github(self) -> str:
+        return "::{severity} file={file},line={start},endLine={end},title={title}::{message}".format(
+            severity=self._to_github_severity(),
+            title=f"semgrep rule:{str(self.check_id)}",
+            file=str(self.path),
+            start=str(self.line),
+            end=str(self.end_line),
+            message=str(self.message),
+        )
+
+    def _to_github_severity(self) -> str:
+        conversion_table: Dict[int, str] = {
+            0: "notice",
+            1: "warning",
+            2: "error",
+        }
+        return conversion_table.get(self.severity, "notice")
+
     def to_gitlab(self) -> Dict[str, Any]:
         return {
             "id": str(uuid.uuid5(uuid.NAMESPACE_URL, str(self.path))),

--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -140,7 +140,7 @@ class Finding:
             file=str(self.path),
             start=str(self.line),
             end=str(self.end_line),
-            message=str(self.message),
+            message=str(self.message).replace("\n", " "),
         )
 
     def _to_github_severity(self) -> str:

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -343,14 +343,9 @@ def protected_main(
 
     new_findings = results.findings.new
     errors = results.findings.errors
-
-    # Additional github annotation output
-    if github_output:
-        click.echo("=== github annotation output", err=True)
-        click.echo("\n".join([f.to_github() for f in new_findings]))
+    blocking_findings = {finding for finding in new_findings if finding.is_blocking()}
 
     click.echo("=== findings", err=True)
-    blocking_findings = {finding for finding in new_findings if finding.is_blocking()}
     if json_output:
         # Output all new findings as json
         json_contents = [f.to_dict(omit=set()) for f in new_findings]
@@ -366,6 +361,11 @@ def protected_main(
     else:
         # Print out blocking findings
         formatter.dump(blocking_findings)
+
+        # Additional github annotation output
+        if github_output:
+            click.echo("=== github annotation output", err=True)
+            click.echo("\n".join([f.to_github() for f in new_findings]))
 
     non_blocking_findings = {
         finding for finding in new_findings if not finding.is_blocking()

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -121,6 +121,14 @@ def url(string: str) -> str:
     "--json", "json_output", envvar="SEMGREP_JSON_OUTPUT", hidden=True, is_flag=True
 )
 @click.option(
+    "--github/--no-github",
+    "github_output",
+    help="Additionally output findings in github annotation format",
+    envvar="SEMGREP_GITHUB_OUTPUT",
+    default=os.getenv("GITHUB_ACTIONS") == "true",
+    is_flag=True,
+)
+@click.option(
     "--gitlab-json",
     "gitlab_output",
     envvar="SEMGREP_GITLAB_JSON",
@@ -156,6 +164,7 @@ def main(
     enable_metrics: bool,
     rewrite_rule_ids: bool,
     json_output: bool,
+    github_output: bool,
     gitlab_output: bool,
     audit_on: Sequence[str],
     timeout: int,
@@ -215,6 +224,7 @@ def protected_main(
     enable_metrics: bool,
     rewrite_rule_ids: bool,
     json_output: bool,
+    github_output: bool,
     gitlab_output: bool,
     audit_on: Sequence[str],
     timeout: int,
@@ -334,6 +344,12 @@ def protected_main(
     new_findings = results.findings.new
     errors = results.findings.errors
 
+    # Additional github annotation output
+    if github_output:
+        click.echo("=== github annotation output", err=True)
+        click.echo("\n".join([f.to_github() for f in new_findings]))
+
+    click.echo("=== findings", err=True)
     blocking_findings = {finding for finding in new_findings if finding.is_blocking()}
     if json_output:
         # Output all new findings as json

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -345,7 +345,6 @@ def protected_main(
     errors = results.findings.errors
     blocking_findings = {finding for finding in new_findings if finding.is_blocking()}
 
-    click.echo("=== findings", err=True)
     if json_output:
         # Output all new findings as json
         json_contents = [f.to_dict(omit=set()) for f in new_findings]
@@ -359,13 +358,13 @@ def protected_main(
         }
         click.echo(json.dumps(gitlab_contents))
     else:
-        # Print out blocking findings
-        formatter.dump(blocking_findings)
-
         # Additional github annotation output
         if github_output:
             click.echo("=== github annotation output", err=True)
             click.echo("\n".join([f.to_github() for f in new_findings]))
+
+        # Print out blocking findings
+        formatter.dump(blocking_findings)
 
     non_blocking_findings = {
         finding for finding in new_findings if not finding.is_blocking()

--- a/tests/acceptance/semgrep-rules-repo/commands.yaml
+++ b/tests/acceptance/semgrep-rules-repo/commands.yaml
@@ -44,13 +44,21 @@ steps:
     expected_out: local-config-some-new-results-gitlab-json.out
     returncode: 1
   - name: local-config-some-new-results-github-env-json
-    description: baseline ref should be used in github actions context
+    description: baseline ref should be used in github actions context and produce json
     command:
       - bash
       - -c
       - "GITHUB_ACTIONS=true semgrep-agent --config python/django/security/audit/xss/template-translate-as-no-escape.yaml --baseline-ref=HEAD~1 --json"
     expected_err: local-config-some-new-results-github-env-json.err
     expected_out: local-config-some-new-results-github-env-json.out
+  - name: local-config-some-new-results-github-annotated
+    description: baseline ref should be used in github actions context
+    command:
+      - bash
+      - -c
+      - "GITHUB_ACTIONS=true semgrep-agent --config python/django/security/audit/xss/template-translate-as-no-escape.yaml --baseline-ref=HEAD~1"
+    expected_err: local-config-some-new-results-github-env.err
+    expected_out: local-config-some-new-results-github-env.out
     returncode: 1
   - name: local-config-some-new-results-gitlab-env-json
     description: baseline ref should be used in gitlab ci context

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-github-env.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-github-env.err
@@ -1,0 +1,16 @@
+| versions          - semgrep x.y.z on Python x.y.z
+| environment       - running in environment github-actions, triggering event is 'unknown'
+| manage            - not logged in
+=== setting up agent configuration
+| using semgrep rules from python/django/security/audit/xss/template-translate-as-no-escape.yaml
+| using default path ignore rules of common test and dependency directories
+| reporting findings introduced by these commits:
+|   * aaaaaaa XSS via translate filters in Django Templates (#1071)
+| looking at 6 changed paths
+| found 6 files in the paths to be scanned
+=== looking for current issues in 6 files
+| 2 current issues found
+| No issues muted with nosemgrep comment
+=== not looking at pre-existing issues since all files with current issues are newly created
+=== github annotation output
+=== exiting with failing status

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-github-env.out
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-github-env.out
@@ -1,11 +1,5 @@
-::notice file=python/django/security/audit/xss/template-translate-as-no-escape.html,line=8,endLine=9,title=semgrep rule:python.django.security.audit.xss.template-translate-as-no-escape::Translated strings will not be escaped when rendered in a template.
-This leads to a vulnerability where translators could include malicious script tags in their translations.
-Consider using `force_escape` to explicitly escape a transalted text.
-
-::notice file=python/django/security/audit/xss/template-translate-as-no-escape.html,line=2,endLine=4,title=semgrep rule:python.django.security.audit.xss.template-translate-as-no-escape::Translated strings will not be escaped when rendered in a template.
-This leads to a vulnerability where translators could include malicious script tags in their translations.
-Consider using `force_escape` to explicitly escape a transalted text.
-
+::notice file=python/django/security/audit/xss/template-translate-as-no-escape.html,line=8,endLine=9,title=semgrep rule:python.django.security.audit.xss.template-translate-as-no-escape::Translated strings will not be escaped when rendered in a template. This leads to a vulnerability where translators could include malicious script tags in their translations. Consider using `force_escape` to explicitly escape a transalted text.
+::notice file=python/django/security/audit/xss/template-translate-as-no-escape.html,line=2,endLine=4,title=semgrep rule:python.django.security.audit.xss.template-translate-as-no-escape::Translated strings will not be escaped when rendered in a template. This leads to a vulnerability where translators could include malicious script tags in their translations. Consider using `force_escape` to explicitly escape a transalted text.
 python.django.security.audit.xss.template-translate-as-no-escape
      > python/django/security/audit/xss/template-translate-as-no-escape.html:2
      ╷

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-github-env.out
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-github-env.out
@@ -1,0 +1,31 @@
+::notice file=python/django/security/audit/xss/template-translate-as-no-escape.html,line=8,endLine=9,title=semgrep rule:python.django.security.audit.xss.template-translate-as-no-escape::Translated strings will not be escaped when rendered in a template.
+This leads to a vulnerability where translators could include malicious script tags in their translations.
+Consider using `force_escape` to explicitly escape a transalted text.
+
+::notice file=python/django/security/audit/xss/template-translate-as-no-escape.html,line=2,endLine=4,title=semgrep rule:python.django.security.audit.xss.template-translate-as-no-escape::Translated strings will not be escaped when rendered in a template.
+This leads to a vulnerability where translators could include malicious script tags in their translations.
+Consider using `force_escape` to explicitly escape a transalted text.
+
+python.django.security.audit.xss.template-translate-as-no-escape
+     > python/django/security/audit/xss/template-translate-as-no-escape.html:2
+     ╷
+    2│   {% translate "Hello world" as the_title %}
+    3│   <div>
+    4│   <h1>{{ the_title }}</h1>
+     ╵
+     = Translated strings will not be escaped when rendered in a template. This
+       leads to a vulnerability where translators could include malicious script
+       tags in their translations. Consider using `force_escape` to explicitly
+       escape a transalted text.
+
+python.django.security.audit.xss.template-translate-as-no-escape
+     > python/django/security/audit/xss/template-translate-as-no-escape.html:8
+     ╷
+    8│   {% trans "Hello world" as title %}
+    9│   <p>{{ title }}</p>
+     ╵
+     = Translated strings will not be escaped when rendered in a template. This
+       leads to a vulnerability where translators could include malicious script
+       tags in their translations. Consider using `force_escape` to explicitly
+       escape a transalted text.
+


### PR DESCRIPTION
This is the `semgrep_agent` version of https://github.com/returntocorp/semgrep/pull/4001 It adds the [github annotation output format](https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-a-notice-message) to the output. 

I wasn't sure what the ideal set of outputs was. Since everything shares standard out, I made this an optional, additional,  output when not using gitlab or json. I kinda wanted to add a `=== findings` heading, but that changes all the test data. 

Probably the best way to test is to make a docker container, and try it in a repo somewhere

### Security

- [ ] Change has no security implications (otherwise, ping the security team)
