### PR TITLE
Use baseline scans for both muted and unmuted issues

### DIFF
--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -233,3 +233,7 @@ class FindingSets:
     @property
     def new(self) -> Set[Finding]:
         return self.current - self.baseline
+
+    @property
+    def new_ignored(self) -> Set[Finding]:
+        return self.ignored - self.baseline

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -202,7 +202,7 @@ def get_findings(
                 err=True,
             )
 
-    if not findings.current:
+    if not findings.current and not findings.ignored:
         click.echo(
             "=== not looking at pre-existing issues since there are no current issues",
             err=True,

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -209,7 +209,9 @@ def get_findings(
         )
     else:
         with targets.baseline_paths() as paths:
-            paths_with_findings = {finding.path for finding in findings.current.union(findings.ignored)}
+            paths_with_findings = {
+                finding.path for finding in findings.current.union(findings.ignored)
+            }
             paths_to_check = list(
                 set(str(path) for path in paths) & paths_with_findings
             )

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -209,7 +209,7 @@ def get_findings(
         )
     else:
         with targets.baseline_paths() as paths:
-            paths_with_findings = {finding.path for finding in findings.current}
+            paths_with_findings = {finding.path for finding in findings.current.union(findings.ignored)}
             paths_to_check = list(
                 set(str(path) for path in paths) & paths_with_findings
             )
@@ -245,6 +245,7 @@ def get_findings(
 
                     args = [
                         "--skip-unknown-extensions",
+                        "--disable-nosem",
                         "--json",
                         "--disable-metrics",  # only count one semgrep run per semgrep-agent run
                         *rewrite_args,

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -234,7 +234,9 @@ class Sapp:
         response = self.session.post(
             f"{self.url}/api/agent/scan/{self.scan.id}/ignores",
             json={
-                "findings": [finding.to_dict() for finding in results.findings.new_ignored],
+                "findings": [
+                    finding.to_dict() for finding in results.findings.new_ignored
+                ],
             },
             timeout=30,
         )

--- a/src/semgrep_agent/semgrep_app.py
+++ b/src/semgrep_agent/semgrep_app.py
@@ -234,7 +234,7 @@ class Sapp:
         response = self.session.post(
             f"{self.url}/api/agent/scan/{self.scan.id}/ignores",
             json={
-                "findings": [finding.to_dict() for finding in results.findings.ignored],
+                "findings": [finding.to_dict() for finding in results.findings.new_ignored],
             },
             timeout=30,
         )


### PR DESCRIPTION
We were not treating muted issues as issues that should get removed via baseline scanning, but this results in confusing behavior where a new (muted) issue shows up in the findings panel with an unassociated PR.

Fixes PD-674

### Security

- [x] Change has no security implications (otherwise, ping the security team)
