### PR TITLE
Ignore .semgrep.yml by default

### DIFF
--- a/src/semgrep_agent/templates/.semgrepignore
+++ b/src/semgrep_agent/templates/.semgrepignore
@@ -20,5 +20,6 @@ test/
 tests/
 *_test.go
 
-# Semgrep rules folder
-.semgrep
+# Default Semgrep rule locations
+.semgrep/
+.semgrep.yml


### PR DESCRIPTION
Ran into an issue with a scan creating false positives on semgrep's own `.semgrep.yml` file, so let's ignore it by default in addition to the existing `.semgrep/` folder ignore.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
