### PR TITLE
Add --gitlab-secrets-json

### DIFF
--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -166,18 +166,11 @@ class Finding:
 
     def to_gitlab_secrets(self) -> Dict[str, Any]:
 
-        # IDs need to be persistent across findings for the same issue
-        # This needs to account for the same rule matching in different
-        # files and the same file
-        # file_path + check_id + matching lines = uniqueness
-        id_hash = sha224(
-            self.path.encode("utf-8")
-            + self.check_id.encode("utf-8")
-            + str(self.line).encode("utf-8")
-            + str(self.end_line).encode("utf-8")
-        ).hexdigest()
         return {
-            "id": id_hash,
+            # IDs need to be persistent across findings for the same issue
+            # This needs to account for the same rule matching in different
+            # files and the same file -- even on the same syntactic value
+            "id": str(self.syntactic_identifier_int()),
             "category": "secret_detection",
             # CVE is a required field from Gitlab schema.
             # It also is part of the determination for uniqueness

--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -170,7 +170,7 @@ class Finding:
             # IDs need to be persistent across findings for the same issue
             # This needs to account for the same rule matching in different
             # files and the same file -- even on the same syntactic value
-            "id": str(self.syntactic_identifier_int()),
+            "id": self.syntactic_identifier_str(),
             "category": "secret_detection",
             # CVE is a required field from Gitlab schema.
             # It also is part of the determination for uniqueness

--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -359,6 +359,7 @@ def protected_main(
         }
         click.echo(json.dumps(gitlab_contents))
     elif gitlab_secrets_output:
+        # schema https://gitlab.com/gitlab-org/security-products/security-report-schemas/-/blob/master/dist/secret-detection-report-format.json
         # output all new findings in Gitlab secret detection format
         gitlab_contents = {
             "version": "14.0.0",

--- a/tests/assets/resources/gitlab_secrets_schema.json
+++ b/tests/assets/resources/gitlab_secrets_schema.json
@@ -1,0 +1,366 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Report format for GitLab Secret Detection",
+    "description": "This schema provides the report format for secret detection analyzers (https://docs.gitlab.com/ee/user/application_security/secret_detection/).",
+    "self": {
+      "version": "14.0.0"
+    },
+    "required": [
+      "version",
+      "vulnerabilities"
+    ],
+    "additionalProperties": true,
+    "properties": {
+      "scan": {
+        "type": "object",
+        "required": [
+          "end_time",
+          "scanner",
+          "start_time",
+          "status",
+          "type"
+        ],
+        "properties": {
+          "end_time": {
+            "type": "string",
+            "description": "ISO8601 UTC value with format yyyy-mm-ddThh:mm:ss, representing when the scan finished.",
+            "examples": [
+              "2020-01-28T03:26:02"
+            ]
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "description": "Communication intended for the initiator of a scan.",
+              "required": [
+                "level",
+                "value"
+              ],
+              "properties": {
+                "level": {
+                  "type": "string",
+                  "description": "Describes the severity of the communication. Use info to communicate normal scan behaviour; warn to communicate a potentially recoverable problem, or a partial error; fatal to communicate an issue that causes the scan to halt.",
+                  "enum": [
+                    "info",
+                    "warn",
+                    "fatal"
+                  ],
+                  "examples": [
+                    "info"
+                  ]
+                },
+                "value": {
+                  "type": "string",
+                  "description": "The message to communicate.",
+                  "examples": [
+                    "Permission denied, scanning aborted"
+                  ]
+                }
+              }
+            }
+          },
+          "scanner": {
+            "type": "object",
+            "description": "Object defining the scanner used to perform the scan.",
+            "required": [
+              "id",
+              "name",
+              "version",
+              "vendor"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique id that identifies the scanner.",
+                "examples": [
+                  "my-secret-detection-scanner"
+                ]
+              },
+              "name": {
+                "type": "string",
+                "description": "A human readable value that identifies the scanner, not required to be unique.",
+                "examples": [
+                  "My Secret Scanner"
+                ]
+              },
+              "url": {
+                "type": "string",
+                "description": "A link to more information about the scanner.",
+                "examples": [
+                  "https://scanner.url"
+                ]
+              },
+              "version": {
+                "type": "string",
+                "description": "The version of the scanner.",
+                "examples": [
+                  "1.0.2"
+                ]
+              },
+              "vendor": {
+                "type": "object",
+                "description": "The vendor/maintainer of the scanner.",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the vendor.",
+                    "examples": [
+                      "GitLab"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "start_time": {
+            "type": "string",
+            "description": "ISO8601 UTC value with format yyyy-mm-ddThh:mm:ss, representing when the scan started.",
+            "examples": [
+              "2020-02-14T16:01:59"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "description": "Result of the scan.",
+            "enum": [
+              "success",
+              "failure"
+            ]
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of the scan.",
+            "enum": [
+              "secret_detection",
+            ]
+          }
+        }
+      },
+      "schema": {
+        "type": "string",
+        "description": "URI pointing to the validating security report schema.",
+        "format": "uri"
+      },
+      "version": {
+        "type": "string",
+        "description": "Report syntax version used to generate this JSON.",
+        "pattern": "^[0-9]+\\.[0-9]+\\.?[0-9]*$"
+      },
+      "vulnerabilities": {
+        "type": "array",
+        "description": "Array of vulnerability objects.",
+        "items": {
+          "type": "object",
+          "description": "Describes the vulnerability.",
+          "required": [
+            "category",
+            "cve",
+            "identifiers",
+            "location",
+            "scanner"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Unique identifier of the vulnerability. This is recommended to be a UUID.",
+              "examples": [
+                "642735a5-1425-428d-8d4e-3c854885a3c9"
+              ]
+            },
+            "category": {
+              "type": "string",
+              "description": "Describes where this vulnerability belongs (for example, SAST, Dependency Scanning, and so on)."
+            },
+            "name": {
+              "type": "string",
+              "description": "The name of the vulnerability. This must not include the finding's specific information."
+            },
+            "message": {
+              "type": "string",
+              "description": "A short text section that describes the vulnerability. This may include the finding's specific information."
+            },
+            "description": {
+              "type": "string",
+              "description": "A long text section describing the vulnerability more fully."
+            },
+            "cve": {
+              "type": "string",
+              "description": "(Deprecated - use vulnerabilities[].id instead) A fingerprint string value that represents a concrete finding. This is used to determine whether two findings are same, which may not be 100% accurate. Note that this is NOT a CVE as described by https://cve.mitre.org/."
+            },
+            "severity": {
+              "type": "string",
+              "description": "How much the vulnerability impacts the software. Possible values are Info, Unknown, Low, Medium, High, or Critical. Note that some analyzers may not report all these possible values.",
+              "enum": [
+                "Info",
+                "Unknown",
+                "Low",
+                "Medium",
+                "High",
+                "Critical"
+              ]
+            },
+            "confidence": {
+              "type": "string",
+              "description": "How reliable the vulnerability's assessment is. Possible values are Ignore, Unknown, Experimental, Low, Medium, High, and Confirmed. Note that some analyzers may not report all these possible values.",
+              "enum": [
+                "Ignore",
+                "Unknown",
+                "Experimental",
+                "Low",
+                "Medium",
+                "High",
+                "Confirmed"
+              ]
+            },
+            "solution": {
+              "type": "string",
+              "description": "Explanation of how to fix the vulnerability."
+            },
+            "scanner": {
+              "description": "Describes the scanner used to find this vulnerability.",
+              "type": "object",
+              "required": [
+                "id",
+                "name"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "The scanner's ID, as a snake_case string."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Human-readable name of the scanner."
+                }
+              }
+            },
+            "identifiers": {
+              "type": "array",
+              "minItems": 1,
+              "description": "An ordered array of references that identify a vulnerability on internal or external databases. The first identifier is the Primary Identifier, which has special meaning.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "type",
+                  "name",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": "for example, cve, cwe, osvdb, usn, or an analyzer-dependent type such as gemnasium)."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Human-readable name of the identifier."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "URL of the identifier's documentation.",
+                    "format": "uri"
+                  },
+                  "value": {
+                    "type": "string",
+                    "description": "Value of the identifier, for matching purpose."
+                  }
+                }
+              }
+            },
+            "links": {
+              "type": "array",
+              "description": "An array of references to external documentation or articles that describe the vulnerability.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "url"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the vulnerability details link."
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "URL of the vulnerability details document.",
+                    "format": "uri"
+                  }
+                }
+              }
+            },
+            "location": {
+              "type": "object",
+              "description": "Identifies the vulnerability's location.",
+              "properties": {
+                "file": {
+                  "type": "string",
+                  "description": "Path to the file where the vulnerability is located."
+                },
+                "start_line": {
+                  "type": "number",
+                  "description": "The first line of the code affected by the vulnerability."
+                },
+                "end_line": {
+                  "type": "number",
+                  "description": "The last line of the code affected by the vulnerability."
+                },
+                "class": {
+                  "type": "string",
+                  "description": "Provides the name of the class where the vulnerability is located."
+                },
+                "method": {
+                  "type": "string",
+                  "description": "Provides the name of the method where the vulnerability is located."
+                }
+              }
+            },
+            "raw_source_code_extract": {
+              "type": "string",
+              "description": "Provides an unsanitized excerpt of the affected source code."
+            }
+          }
+        }
+      },
+      "remediations": {
+        "type": "array",
+        "description": "An array of objects containing information on available remediations, along with patch diffs to apply.",
+        "items": {
+          "type": "object",
+          "required": [
+            "fixes",
+            "summary",
+            "diff"
+          ],
+          "properties": {
+            "fixes": {
+              "type": "array",
+              "description": "An array of strings that represent references to vulnerabilities fixed by this remediation.",
+              "items": {
+                "type": "object",
+                "required": [
+                  "cve"
+                ],
+                "properties": {
+                  "cve": {
+                    "type": "string",
+                    "description": "(Deprecated - use vulnerabilities[].id instead) A fingerprint string value that represents a concrete finding. This is used to determine whether two findings are same, which may not be 100% accurate. Note that this is NOT a CVE as described by https://cve.mitre.org/."
+                  }
+                }
+              }
+            },
+            "summary": {
+              "type": "string",
+              "description": "An overview of how the vulnerabilities were fixed."
+            },
+            "diff": {
+              "type": "string",
+              "description": "A base64-encoded remediation code diff, compatible with git apply."
+            }
+          }
+        }
+      }
+    }
+  }

--- a/tests/assets/resources/gitlab_secrets_schema.json
+++ b/tests/assets/resources/gitlab_secrets_schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Report format for GitLab Secret Detection",
-    "description": "This schema provides the report format for secret detection analyzers (https://docs.gitlab.com/ee/user/application_security/secret_detection/).",
+    "description": "This schema provides the report format for Secret Detection analyzers (https://docs.gitlab.com/ee/user/application_security/secret_detection/).",
     "self": {
       "version": "14.0.0"
     },
@@ -74,7 +74,7 @@
                 "type": "string",
                 "description": "Unique id that identifies the scanner.",
                 "examples": [
-                  "my-secret-detection-scanner"
+                  "my-secret-scanner"
                 ]
               },
               "name": {
@@ -135,7 +135,7 @@
             "type": "string",
             "description": "Type of the scan.",
             "enum": [
-              "secret_detection",
+              "secret_detection"
             ]
           }
         }
@@ -173,7 +173,7 @@
             },
             "category": {
               "type": "string",
-              "description": "Describes where this vulnerability belongs (for example, SAST, Dependency Scanning, and so on)."
+              "description": "Describes where this vulnerability belongs (e.g. SAST, Secret Detection)."
             },
             "name": {
               "type": "string",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,9 @@ def _run_semgrep_agent(
     if output_format == "gitlab":
         options.append("--gitlab-json")
 
+    if output_format == "gitlab-secrets":
+        options.append("--gitlab-secrets-json")
+
     process = subprocess.run(
         ["python", "-m", "semgrep_agent", *options],
         encoding="utf-8",
@@ -53,7 +56,7 @@ def _run_semgrep_agent(
 
     print(f"--- stderr start ---\n{process.stderr}\n--- stderr end ---")
 
-    if output_format in {"json", "gitlab"} and not stderr:
+    if output_format in {"json", "gitlab", "gitlab-secrets"} and not stderr:
         output = _clean_output_json(process.stdout)
     else:
         output = process.stdout

--- a/tests/test_gitlab_secret_output.py
+++ b/tests/test_gitlab_secret_output.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+from jsonschema import validate
+
+
+def test_gitlab_secret_output(run_semgrep_agent, get_test_root):
+    gitlab_secrets_output = run_semgrep_agent(
+        config="assets/rules/eqeq.yaml", output_format="gitlab-secrets"
+    )
+    schema_path = str(
+        Path(get_test_root / "assets/resources/gitlab_secrets_schema.json").resolve()
+    )
+    with open(schema_path) as f:
+        gitlab_secrets_schema = json.load(f)
+        validate(gitlab_secrets_output, schema=gitlab_secrets_schema)


### PR DESCRIPTION
Gitlab has moved to a separate scanner type and schema for secret detection.  These results are reported and stored distinct from SAST findings.  The current secret detection schema is reflected at 14.0.0. 

* Note CVE is meaningful in terms of determining unique findings here
* Additional scanner information is included compared to SAST
* Added start and end times for reporting back to gitlab
* Tested on gitlab SaaS offering using generic.secrets.security.detected-aws-access-key-id-value

### Security

- [x] Change has no security implications (otherwise, ping the security team)
