### PR TITLE
REVERT: Release 0.72.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9.7-alpine
 WORKDIR /app
 COPY poetry.lock pyproject.toml ./
 
-ENV INSTALLED_SEMGREP_VERSION=0.72.0
+ENV INSTALLED_SEMGREP_VERSION=0.71.0
 
 # This is all in one run command in order to save disk space.
 # Note that there's a tradeoff here for debuggability.


### PR DESCRIPTION
There is a serious bug in 0.72.0 that causes Semgrep to analyze .png and
other binary files, and crash with Pcre.Error(BadUTF8). This affects
paying customers. Rolling back to 0.71.0 until this is fixed.

Related-to: returntocorp/semgrep#4258

### Security

- [x] Change has no security implications (otherwise, ping the security team)
