### PR TITLE
feat(semgrep): call with timeout-threshold

### DIFF
--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -277,7 +277,7 @@ def _get_head_findings(
             "--dryrun",
             "--time",
             "--timeout-threshold",
-            "5",
+            "3",
             *extra_args,
         ]
         exit_code, semgrep_output = invoke_semgrep(

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -276,6 +276,8 @@ def _get_head_findings(
             "--autofix",
             "--dryrun",
             "--time",
+            "--timeout-threshold",
+            "5",
             *extra_args,
         ]
         exit_code, semgrep_output = invoke_semgrep(


### PR DESCRIPTION
If a file times out with semgrep on 3 rules, it will no longer
send the file for analysis with other rules since we will likely just keep timing out

### Security

- [ ] Change has no security implications (otherwise, ping the security team)
