### PR TITLE
Fix failing when running with --config auto

### DIFF
--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -394,8 +394,8 @@ def _update_baseline_findings(
                         *config_args,
                     ]
 
-                    # Can only disable metrics if auto is not a passed config
-                    # disable so only one metrics run per semgrep-action run
+                    # If possible, disable metrics so that we get metrics only once per semgrep-action run
+                    # However, if run with config auto we must allow metrics to be sent
                     if "auto" not in config_args:
                         args.extend(["--metrics", "off"])
 

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -390,11 +390,15 @@ def _update_baseline_findings(
                         "--skip-unknown-extensions",
                         "--disable-nosem",
                         "--json",
-                        "--metrics",
-                        "off",  # only count one semgrep run per semgrep-agent run
                         *extra_args,
                         *config_args,
                     ]
+
+                    # Can only disable metrics if auto is not a passed config
+                    # disable so only one metrics run per semgrep-action run
+                    if "auto" not in config_args:
+                        args.extend(["--metrics", "off"])
+
                     _, semgrep_output = invoke_semgrep(
                         args, paths_to_check, timeout=context.timeout
                     )


### PR DESCRIPTION
User was reporting semgrep-action failing with JSONDecodeError when doing a baseline scan. Locally semgrep was working fine. User was running with semgrep-action --config auto.

Failure was due to semgrep aborting with auto was used with metrics off.