### PR TITLE
Catch error debug_echo

### DIFF
--- a/src/semgrep_agent/utils.py
+++ b/src/semgrep_agent/utils.py
@@ -42,7 +42,12 @@ def debug_echo(text: str) -> None:
     else:
         logging.info(text)
         return
-    text = "\n".join(prefix + line for line in text.splitlines())
+    try:
+        modified_text = "\n".join(prefix + line for line in text.splitlines())
+        text = modified_text
+    except Exception as e:
+        logging.info(e)
+
     click.echo(text, err=True)
 
 


### PR DESCRIPTION
From https://github.com/returntocorp/semgrep-action/issues/429 looks like sh passes bytes object to the _err command. Looks like an exception thrown while handling stderr of a sh command causes us to deadlock somehow maybe because the stderr pipe can never be closed. Just shove it in try catch for now but sh commands should probably call a different function

### Security

- [ ] Change has no security implications (otherwise, ping the security team)
