### PR TITLE
Fix Semgrep error reporting

### DIFF
--- a/src/semgrep_agent/utils.py
+++ b/src/semgrep_agent/utils.py
@@ -63,7 +63,10 @@ def maybe_print_debug_info(meta: "GitMeta") -> None:
 
 def render_error(error: Mapping[str, Any]) -> Sequence[str]:
     spans = error.get("spans")
-    msg = error.get("long_msg", "")
+    msg: str = error.get("long_msg", error.get("message", ""))
+    newline_ix = msg.find("\n")
+    if newline_ix > -1:
+        msg = msg[: newline_ix - 1]
     if spans:
         return [f"{s['file']}:{s['start']['line']} {msg}" for s in spans]
     return [msg]

--- a/src/semgrep_agent/utils.py
+++ b/src/semgrep_agent/utils.py
@@ -64,6 +64,9 @@ def maybe_print_debug_info(meta: "GitMeta") -> None:
 def render_error(error: Mapping[str, Any]) -> Sequence[str]:
     spans = error.get("spans")
     msg: str = error.get("long_msg", error.get("message", ""))
+    # semgrep-core errors sometimes include extremely long stack traces;
+    # These aren't useful to the user, and should properly belong in a log
+    # artifact instead. Therefore, truncate messages to the first line.
     newline_ix = msg.find("\n")
     if newline_ix > -1:
         msg = msg[: newline_ix - 1]

--- a/tests/unit/test_render_error.py
+++ b/tests/unit/test_render_error.py
@@ -1,0 +1,45 @@
+import json
+
+from semgrep_agent.utils import render_error
+
+SEMGREP_OUT = """
+{
+  "errors": [
+    {
+      "code": 3,
+      "level": "warn",
+      "message": "Semgrep Core WARN - Syntax error: When running javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret on frontend/src/r2components/table/DataTable.tsx: `}: DataTableProps<` was unexpected",
+      "path": "frontend/src/r2components/table/DataTable.tsx",
+      "rule_id": "javascript.jsonwebtoken.security.jwt-hardcode.hardcoded-jwt-secret",
+      "type": "Syntax error"
+    },
+    {
+      "code": 3,
+      "level": "warn",
+      "message": "Semgrep Core WARN - Syntax error: When running javascript.lang.correctness.useless-eqeq.eqeq-is-bad on frontend/src/r2components/table/DataTable.tsx: `}: DataTableProps<` was unexpected",
+      "path": "frontend/src/r2components/table/DataTable.tsx",
+      "rule_id": "javascript.lang.correctness.useless-eqeq.eqeq-is-bad",
+      "type": "Syntax error"
+    },
+    {
+      "code": 3,
+      "level": "warn",
+      "message": "Semgrep Core WARN - Syntax error: When running typescript.react.security.react-markdown-insecure-html.react-markdown-insecure-html on frontend/src/r2components/table/DataTable.tsx: `}: DataTableProps<` was unexpected",
+      "path": "frontend/src/r2components/table/DataTable.tsx",
+      "rule_id": "typescript.react.security.react-markdown-insecure-html.react-markdown-insecure-html",
+      "type": "Syntax error"
+    }
+  ],
+  "results": []
+}
+"""
+
+RENDERED_ERROR = [
+    "Semgrep Core WARN - Syntax error: When running javascript.lang.correctness.useless-eqeq.eqeq-is-bad on frontend/src/r2components/table/DataTable.tsx: `}: DataTableProps<` was unexpected"
+]
+
+
+def test_render_error():
+    data = json.loads(SEMGREP_OUT)
+
+    assert render_error(data["errors"][1]) == RENDERED_ERROR


### PR DESCRIPTION
long_msg was removed from core error JSON blobs, breaking error reporting.
Fix by falling back to the "message" field.

Also truncate at new lines to avoid spam.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
