### PR TITLE
Revert "Build beta tag"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - "**"
     tags:
       - "v*"
-      - "beta"
   pull_request:
 
 jobs:


### PR DESCRIPTION
Reverts returntocorp/semgrep-action#460

Referring to a different tag than v1 didnt work the way I assumed it did 