### PR TITLE
Remove env/ and venv/ from default .semgrepignore

### DIFF
--- a/src/semgrep_agent/templates/.semgrepignore
+++ b/src/semgrep_agent/templates/.semgrepignore
@@ -8,9 +8,7 @@ node_modules/
 build/
 dist/
 vendor/
-env/
 .env/
-venv/
 .venv/
 .tox/
 *.min.js


### PR DESCRIPTION
We removed these patterns from the default set of ignore patterns in the CLI. This keeps the action consistent.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
