### PR TITLE
feat(output): clarify number of new vs pre-existing issues

### DIFF
--- a/src/semgrep_agent/findings.py
+++ b/src/semgrep_agent/findings.py
@@ -284,3 +284,7 @@ class FindingSets:
     @property
     def new_ignored(self) -> Set[Finding]:
         return self.ignored - self.baseline
+
+    @property
+    def new_all(self) -> Set[Finding]:
+        return self.new.union(self.new_ignored)

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -326,7 +326,7 @@ def _get_head_findings(
             err=True,
         )
         click.echo(
-            f"| {unit_len(findings.ignored, 'issue')} muted with nosemgrep comment",
+            f"| {unit_len(findings.ignored, 'issue')} muted with nosemgrep comment (not counted as current)",
             err=True,
         )
     return findings, stats
@@ -415,8 +415,11 @@ def _update_baseline_findings(
                     for finding in findings.baseline:
                         if finding.is_cai_finding():
                             inventory_findings_len += 1
+                    baseline_findings_count = (
+                        len(findings.baseline) - inventory_findings_len
+                    )
                     click.echo(
-                        f"| {unit_len(range(len(findings.baseline) - inventory_findings_len), 'pre-existing issue')} found",
+                        f"| {unit_len(range(baseline_findings_count), 'current issue')} removed by diffing logic",
                         err=True,
                     )
 

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -325,10 +325,11 @@ def _get_head_findings(
             f"| {unit_len(range(len(findings.current) - inventory_findings_len), 'current issue')} found",
             err=True,
         )
-        click.echo(
-            f"| {unit_len(findings.ignored, 'issue')} muted with nosemgrep comment (not counted as current)",
-            err=True,
-        )
+        if len(findings.ignored) > 0:
+            click.echo(
+                f"| {unit_len(findings.ignored, 'issue')} muted with nosemgrep comment (not counted as current)",
+                err=True,
+            )
     return findings, stats
 
 

--- a/tests/acceptance/baseline-generic/new-agent.err
+++ b/tests/acceptance/baseline-generic/new-agent.err
@@ -10,6 +10,6 @@
 | found 1 file in the paths to be scanned
 === looking for current issues in 1 file
 | 1 current issue found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
+=== analyzing new issues in this scan
 === exiting with failing status

--- a/tests/acceptance/baseline-local-file/new-agent.err
+++ b/tests/acceptance/baseline-local-file/new-agent.err
@@ -10,7 +10,7 @@
 | found 2 files in the paths to be scanned
 === looking for current issues in 2 files
 | 1 current issue found
-| No issues muted with nosemgrep comment
 === .semgrep.yml file not found in baseline, skipping scanning for baseline
 === not looking at pre-exiting issues since after filtering out local files that don't exist in baseline, no configs left to run
+=== analyzing new issues in this scan
 === exiting with failing status

--- a/tests/acceptance/disconnected-generic/disconnected-agent.err
+++ b/tests/acceptance/disconnected-generic/disconnected-agent.err
@@ -9,6 +9,5 @@
 | skipping 1 file based on path ignore rules
 === looking for current issues in 1 file
 | 1 current issue found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/mergebase-generic/new-agent.err
+++ b/tests/acceptance/mergebase-generic/new-agent.err
@@ -14,6 +14,6 @@
 | found 1 file in the paths to be scanned
 === looking for current issues in 1 file
 | 1 current issue found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
+=== analyzing new issues in this scan
 === exiting with failing status

--- a/tests/acceptance/multiconfig-generic/new-agent.err
+++ b/tests/acceptance/multiconfig-generic/new-agent.err
@@ -11,6 +11,6 @@
 | found 1 file in the paths to be scanned
 === looking for current issues in 1 file
 | 1 current issue found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
+=== analyzing new issues in this scan
 === exiting with failing status

--- a/tests/acceptance/mutlimerge-generic/new-agent.err
+++ b/tests/acceptance/mutlimerge-generic/new-agent.err
@@ -11,6 +11,6 @@
 | found 1 file in the paths to be scanned
 === looking for current issues in 1 file
 | No current issues found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since there are no current issues
+=== analyzing new issues in this scan
 === exiting with success status

--- a/tests/acceptance/push-generic/push-agent.err
+++ b/tests/acceptance/push-generic/push-agent.err
@@ -9,6 +9,5 @@
 | skipping 1 file based on path ignore rules
 === looking for current issues in 1 file
 | 1 current issue found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/semgrep-rules-repo/local-config-full-scan.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-full-scan.err
@@ -9,6 +9,5 @@
 | skipping 3 files based on path ignore rules
 === looking for current issues in 1473 files
 | 2 current issues found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
 === exiting with failing status

--- a/tests/acceptance/semgrep-rules-repo/local-config-no-new-results.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-no-new-results.err
@@ -10,6 +10,6 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | No current issues found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since there are no current issues
+=== analyzing new issues in this scan
 === exiting with success status

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-audit-mode.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-audit-mode.err
@@ -10,7 +10,7 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | 2 current issues found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
+=== analyzing new issues in this scan
 | audit mode is on for unknown, so the findings won't cause failure
 === exiting with success status

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-github-env-json.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-github-env-json.err
@@ -10,6 +10,6 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | 2 current issues found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
+=== analyzing new issues in this scan
 === exiting with failing status

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-gitlab-env-json.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-gitlab-env-json.err
@@ -10,6 +10,6 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | 2 current issues found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
+=== analyzing new issues in this scan
 === exiting with failing status

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-gitlab-json.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-gitlab-json.err
@@ -10,6 +10,6 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | 2 current issues found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
+=== analyzing new issues in this scan
 === exiting with failing status

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-json.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results-json.err
@@ -10,6 +10,6 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | 2 current issues found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
+=== analyzing new issues in this scan
 === exiting with failing status

--- a/tests/acceptance/semgrep-rules-repo/local-config-some-new-results.err
+++ b/tests/acceptance/semgrep-rules-repo/local-config-some-new-results.err
@@ -10,6 +10,6 @@
 | found 6 files in the paths to be scanned
 === looking for current issues in 6 files
 | 2 current issues found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since all files with current issues are newly created
+=== analyzing new issues in this scan
 === exiting with failing status

--- a/tests/acceptance/symlink-dir/new-agent.err
+++ b/tests/acceptance/symlink-dir/new-agent.err
@@ -11,6 +11,6 @@
 | found No files in the paths to be scanned
 === looking for current issues in No files
 | No current issues found
-| No issues muted with nosemgrep comment
 === not looking at pre-existing issues since there are no current issues
+=== analyzing new issues in this scan
 === exiting with success status


### PR DESCRIPTION
Our output has confused many users in the past, because pre-existing 
issues are discussed in the output but never uploaded to the app.
This PR is a first step toward clarifying what we are doing with
the diffing logic, so that not all users have to comb our docs
to figure it out.

Long-term there are huge improvements we should still make here by
showing total number of issues in one place, and breakdowns by
- blocking vs non-blocking
- muted vs not-muted
- pre-existing vs new

The way we print things out right now follows the order in which
our code calculates things, which is not the most intuitive way
to summarize this information. I downscoped making this very good,
since I know the goal is to move a lot of this into semgrep itself.
(closes PD-914)

----------
For a diff PR with 1 pre-existing issue only

Before:
<img width="1231" alt="Screen Shot 2021-12-21 at 3 05 01 PM" src="https://user-images.githubusercontent.com/25408780/147008915-efec65aa-bd33-417b-a84d-f2e8444ef487.png">

After:
<img width="1231" alt="Screen Shot 2021-12-21 at 3 15 42 PM" src="https://user-images.githubusercontent.com/25408780/147009785-75364384-31d8-4787-8494-2c2a0df43dd4.png">

---------
For a diff PR with 1 pre-existing issue and 1 new issue (and 1 muted issue because I changed that a little too)

Before:
<img width="1248" alt="Screen Shot 2021-12-21 at 3 21 17 PM" src="https://user-images.githubusercontent.com/25408780/147010202-c550a65c-fa52-4555-9198-b37f8b2523b6.png">

After:
<img width="1241" alt="Screen Shot 2021-12-21 at 3 19 48 PM" src="https://user-images.githubusercontent.com/25408780/147010071-1f3a3c9c-6230-48e2-9f8f-0e00d93c6a37.png">

### Security

- [x] Change has no security implications (otherwise, ping the security team)
