### PR TITLE
Do not error if semgrep_logs have been modified

### DIFF
--- a/src/semgrep_agent/targets.py
+++ b/src/semgrep_agent/targets.py
@@ -273,7 +273,7 @@ class TargetFileManager:
 
         debug_echo("Initializing dirty paths")
         sub_out = subprocess.run(
-            ["git", "status", "--porcelain", "-z"],
+            ["git", "status", "--porcelain", "-z", "':!.semgrep_logs/'"],
             timeout=GIT_SH_TIMEOUT,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,


### PR DESCRIPTION
Semgrep checks whether git state is clean on the baseline branch before performing diff scans. Ignore changes made to `.semgrep_logs/` when doing this.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
