### PR TITLE
Release 0.78.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9.7-alpine
 WORKDIR /app
 COPY poetry.lock pyproject.toml ./
 
-ENV INSTALLED_SEMGREP_VERSION=0.77.0
+ENV INSTALLED_SEMGREP_VERSION=0.78.0
 
 # This is all in one run command in order to save disk space.
 # Note that there's a tradeoff here for debuggability.


### PR DESCRIPTION
### Security

- [x] Change has no security implications (otherwise, ping the security team)
