### PR TITLE
Always ignore .semgrep_logs

### DIFF
--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -129,6 +129,11 @@ def create_semgrepignore(app_ignore_patterns: List[str]) -> None:
         semgrepignore_path = Path(".semgrepignore")
         if semgrepignore_path.is_file():
             semgrepignore.write(semgrepignore_path.read_text())
+
+            # Always ignore .semgrep_logs
+            semgrepignore.write("\n# Semgrep-action log folder")
+            semgrepignore.write("\n.semgrep_logs/")
+            semgrepignore.write("\n")
         else:
 
             semgrepignore.write((TEMPLATES_DIR / ".semgrepignore").read_text())


### PR DESCRIPTION
Adds `.semgrep_logs` to the semgrepignore file that semgrep-action sends to the CLI, no matter what.
### Security

- [x] Change has no security implications (otherwise, ping the security team)
