### PR TITLE
Promote autofix in PR comments

### DIFF
--- a/src/semgrep_agent/main.py
+++ b/src/semgrep_agent/main.py
@@ -271,7 +271,7 @@ def protected_main(
 
     # Setup URL/Token
     if sapp.is_configured:
-        policy = sapp.report_start(meta)
+        sapp.report_start(meta)
         to_server = "" if publish_url == "https://semgrep.dev" else f" to {publish_url}"
         click.echo(
             get_aligned_command(
@@ -280,7 +280,9 @@ def protected_main(
             ),
             err=True,
         )
-        click.echo(get_aligned_command("policy", f"using {policy}"), err=True)
+        click.echo(
+            get_aligned_command("policy", f"using {sapp.scan.policy_list}"), err=True
+        )
     else:
         click.echo(get_aligned_command("manage", f"not logged in"), err=True)
 

--- a/src/semgrep_agent/meta.py
+++ b/src/semgrep_agent/meta.py
@@ -153,7 +153,7 @@ class GithubMeta(GitMeta):
         return self.event_name in {"pull_request", "pull_request_target"}
 
     @cachedproperty
-    def repo_name(self) -> Optional[str]:
+    def repo_name(self) -> str:
         return os.getenv("GITHUB_REPOSITORY", "[unknown]")
 
     @cachedproperty


### PR DESCRIPTION
Instead of hiding autofix in PR comments behind a secret environment variable, users can now specify in the app whether they want to enable autofix on a per-repo basis.

I took this opportunity to also refactor how policy names are stored, since returning them from report_start made less sense than keeping them as a property inside of the scan. These changes are backwards-compatible, so can go in whenever.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
