### PR TITLE
Unpin image from action so rebuilds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9-alpine3.15
 WORKDIR /app
 COPY poetry.lock pyproject.toml ./
 
-ENV INSTALLED_SEMGREP_VERSION=0.83.0
+ENV INSTALLED_SEMGREP_VERSION=0.82.0
 
 
 # This is all in one run command in order to save disk space.

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,7 @@ author: "r2c"
 description: "Easily detect and prevent bugs and anti-patterns in your codebase"
 runs:
   using: "docker"
+  image: "Dockerfile"
 inputs:
   config:
     description: |

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,6 @@ author: "r2c"
 description: "Easily detect and prevent bugs and anti-patterns in your codebase"
 runs:
   using: "docker"
-  image: "docker://returntocorp/semgrep-agent:v1"
 inputs:
   config:
     description: |

--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -496,7 +496,7 @@ def invoke_semgrep(
     for chunk in chunked_iter(targets, PATHS_CHUNK_SIZE):
         with tempfile.NamedTemporaryFile("w") as output_json_file:
             args = semgrep_args.copy()
-            args.extend(["--debug"])
+            # args.extend(["--debug"])
             args.extend(
                 [
                     "-o",


### PR DESCRIPTION
Going to tag this branch and because docker image tag is removed from action it should cause rebuild on every run. This will allow us to test changes on this tag before releasing to v1

Add changes you want to make to semgrep-action
Run `git tag --force edge && git push --force origin edge`
Repo with action: 
```
  semgrep-edge:
    name: semgrep edge with managed policy
    runs-on: ubuntu-20.04
    steps:
      - uses: actions/checkout@v2
        with:
          submodules: recursive
      - uses: returntocorp/semgrep-action@edge
        with:
          publishToken: TOKEN
```
will build and run the tagged branch

### Security
- [ ] Changelog has been updated
- [ ] Change has no security implications (otherwise, ping the security team)
