### PR TITLE
Add environment variable to generate JSON report

### DIFF
--- a/src/semgrep_agent/semgrep.py
+++ b/src/semgrep_agent/semgrep.py
@@ -537,6 +537,16 @@ def invoke_semgrep(
     semgrep_save_file.write("]")
     semgrep_save_file.close()
 
+    if os.getenv("INPUT_GENERATE_JSON_REPORT"):
+        debug_echo("=== generate a Semgrep JSON report")
+        report_path = Path("semgrep-report.json")
+        semgrep_report = {
+            "results": output.results,
+            "errors": output.errors,
+        }
+        with open(report_path, "w") as fh:
+            json.dump(semgrep_report, fh, indent=4)
+
     return max_exit_code, output
 
 


### PR DESCRIPTION
This PR introduces the `INPUT_GENERATE_JSON_REPORT` environment variable that, if set, will have the Semgrep agent write the scan results to a local JSON file named `semgrep-report.json`.

This is modeled after [similar code in the agent](https://github.com/returntocorp/semgrep-action/blob/b025e6ed7c8f25cdba4b7995636bd398b7f6edc4/src/semgrep_agent/semgrep.py#L251-L262) that uses the `INPUT_GENERATESARIF` environment variable to generate a `semgrep.sarif` file.

### Security
- [ ] Changelog has been updated
- [x] Change has no security implications (otherwise, ping the security team)
