### PR TITLE
chore: Bump semgrep to 0.94.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Upcoming - Date
 
+# 2022-05-25
+
+## Changed
+
+- Use semgrep 0.94.0
+
 # 2022-05-12
 
 ## Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM returntocorp/semgrep:0.93.0
+FROM returntocorp/semgrep:0.94.0
 
 USER root
 WORKDIR /semgrep-agent


### PR DESCRIPTION
### Security
- [x] Changelog has been updated
- [x] Change has no security implications (otherwise, ping the security team)
