### PR TITLE
add an on-push-develop release semgrep action workflow

### DIFF
--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -1,0 +1,70 @@
+name: Release Action
+
+on:
+  push:
+    branches:
+      - "develop"
+
+jobs:
+  release-action:
+    name: Release GitHub Action
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get JWT for semgrep-ci GitHub App
+        id: jwt
+        uses: docker://public.ecr.aws/y9k7q4m1/devops/cicd:latest
+        env:
+          EXPIRATION: 600 # seconds
+          ISSUER: ${{ secrets.SEMGREP_CI_APP_ID }} # semgrep-ci GitHub App id
+          PRIVATE_KEY: ${{ secrets.SEMGREP_CI_APP_KEY }}
+      - name: Get token for semgrep-ci GitHub App
+        id: token
+        run: |
+          TOKEN="$(curl -X POST \
+          -H "Authorization: Bearer ${{ steps.jwt.outputs.jwt }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/app/installations/${{ secrets.SEMGREP_CI_APP_INSTALLATION_ID }}/access_tokens" | \
+          jq -r .token)"
+          echo "::add-mask::$TOKEN"
+          echo "::set-output name=token::$TOKEN"
+      - name: Check out code
+        uses: actions/checkout@v3
+        id: checkout
+        with:
+          submodules: "recursive"
+          ref: "${{ github.event.repository.default_branch }}"
+          token: "${{ steps.token.outputs.token }}"
+      - name: Pull Tags
+        id: pull-tags
+        # We don't want a full heavyweight checkout with full history
+        # checkout action only can get tags + full history, so do this separately.
+        # Don't need tags in submodules.
+        run: git fetch --no-recurse-submodules origin 'refs/tags/*:refs/tags/*'
+      - name: Get latest version
+        id: latest-version
+        run: |
+          LATEST_TAG=$(git tag --list "v*.*.*" | sort -V | tail -n 1 | cut -c 2- )
+          echo ::set-output name=latest-version::${LATEST_TAG}
+      - name: Get Next SemVer tag
+        id: next-version
+        uses: christian-draeger/increment-semantic-version@9d04121fb4825e033aeeaaf6d42b44b8b4e81ac5
+        with:
+          current-version: "${{ steps.latest-version.outputs.latest-version }}"
+          version-fragment: "feature"
+      - name: Find Current Semgrep Version (Metadata only)
+        id: semgrep-version
+        run: |
+          SEMGREP_VERSION=$(sed -n 's|FROM returntocorp/semgrep:\(.*\)|\1|p' Dockerfile)
+          echo "::set-output name=semgrep-version::$SEMGREP_VERSION"
+      - name: Add New SemVer (Immutable) Tag
+        id: create-tag
+        run: |
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
+          git tag -a -m "Semgrep Action for Semgrep Version ${{ steps.semgrep-version.outputs.semgrep-version }}" "v${{ steps.next-version.outputs.next-version }}"
+          git push origin "v${{ steps.next-version.outputs.next-version }}"
+      - name: Move Rolling v1 Tag
+        id: create-rolling-tag
+        run: |
+          git tag --force v1
+          git push --tags --force

--- a/tests/acceptance/qa.py
+++ b/tests/acceptance/qa.py
@@ -32,6 +32,9 @@ ENV_VERSIONS = re.compile(
 )
 JSON_VERSION = re.compile(r'"version": "[0-9]+?[.][0-9]+?[.][0-9]+?"')
 GITHUB_ACTIONS_DEBUG = re.compile(r"^::debug::.*?\n", re.MULTILINE)
+NEW_VERSION_AVAILABLE = re.compile(
+    r"\nA new version of Semgrep is available.*\n", re.MULTILINE
+)
 
 PIPE_OUTPUT: Mapping[str, Callable[[subprocess.CompletedProcess], str]] = {
     "expected_out": lambda r: cast(str, r.stdout),
@@ -55,6 +58,7 @@ CLEANING_FUNCS: Sequence[Callable[[str], str]] = [
     lambda s: re.sub(ENV_VERSIONS, r"\1x.y.z\2x.y.z", s),
     lambda s: re.sub(JSON_VERSION, r'"version": "x.y.z"', s),
     lambda s: re.sub(GITHUB_ACTIONS_DEBUG, "", s),
+    lambda s: re.sub(NEW_VERSION_AVAILABLE, "", s),
     lambda s: re.sub(
         SYMLINK_SKIP_MSG,
         "Skipping bar/foo since it is a symlink to a directory: foo",


### PR DESCRIPTION
This PR creates a workflow that does the following on any push to develop:
- Creates a new semantic version tag, bumping the feature version
  - This in turn triggers the `release.yml` job which builds/pushes docker image
- Moves the rolling v1 tag
  - This "releases" the GitHub Action steps that users rely on

This occurs on any push to develop, regardless of if the semgrep version was updated underneath. This decouples this versioning from the semgrep version, and allows us to get some rollback capability in the future.

We also need to "seed" this change by adding an appropriately format semver tag. I'm proposing `v0.5.0` - we already have a `v0.4` and this seems logical.

No changelog entry needed. 

### Security
- [x] Changelog has been updated
- [x] Change has no security implications (otherwise, ping the security team)
