### PR TITLE
add a job to revert semgrep action docker images

### DIFF
--- a/.github/workflows/revert-semgrep-docker-image.yml
+++ b/.github/workflows/revert-semgrep-docker-image.yml
@@ -10,7 +10,6 @@ jobs:
   rollback-docker-image:
     strategy:
       matrix:
-        # TODO: change to real repo (returntocorp/semgrep)
         repo: ['returntocorp/semgrep-action', 'returntocorp/semgrep-agent']
     name: Rollback Docker Image
     runs-on: ubuntu-22.04
@@ -27,8 +26,10 @@ jobs:
       - id: retag
         name: Re-Tag Docker Image
         run: |
+          docker tag ${{ matrix.repo }}:${{ inputs.docker_tag }} ${{ matrix.repo }}:v1
           docker tag ${{ matrix.repo }}:${{ inputs.docker_tag }} ${{ matrix.repo }}:latest
       - id: push
         name: Push New Latest Tag
         run: |
+          docker push ${{ matrix.repo }}:v1
           docker push ${{ matrix.repo }}:latest

--- a/.github/workflows/revert-semgrep-docker-image.yml
+++ b/.github/workflows/revert-semgrep-docker-image.yml
@@ -1,0 +1,34 @@
+name: Revert Semgrep Action Docker Image
+on:
+  workflow_dispatch:
+    inputs:
+      docker_tag:
+        description: "Docker Tag to point 'latest' to, example: 0.5.0. This isn't the version of semgrep, but rather, the tag from this repo."
+        required: true
+
+jobs:
+  rollback-docker-image:
+    strategy:
+      matrix:
+        # TODO: change to real repo (returntocorp/semgrep)
+        repo: ['returntocorp/semgrep-action', 'returntocorp/semgrep-agent']
+    name: Rollback Docker Image
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - id: pull
+        name: Pull Image to Retag as Latest
+        run: |
+          docker pull ${{ matrix.repo }}:${{ inputs.docker_tag }}
+      - id: retag
+        name: Re-Tag Docker Image
+        run: |
+          docker tag ${{ matrix.repo }}:${{ inputs.docker_tag }} ${{ matrix.repo }}:latest
+      - id: push
+        name: Push New Latest Tag
+        run: |
+          docker push ${{ matrix.repo }}:latest


### PR DESCRIPTION
This job allows us to revert the docker tag from latest back to an older image, in case of failures on the customer side. We already have infra in place to tag images based on the git tag - we just need to start building/tagging these images, which'll happen once PR #620 is merged. 

No change log needed.

### Security
- [x] Changelog has been updated
- [x] Change has no security implications (otherwise, ping the security team)
