### PR TITLE
add a job to rollback v1

### DIFF
--- a/.github/workflows/revert-semgrep-action-gha.yml
+++ b/.github/workflows/revert-semgrep-action-gha.yml
@@ -1,0 +1,29 @@
+name: Revert Semgrep Action for GHA
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "version to point 'v1' to, example: 0.1.0"
+        required: true
+
+jobs:
+  release-action:
+    name: Release Semgrep Action
+    runs-on: ubuntu-22.04
+    steps:
+      # Specifically we do NOT use the semgrep-ci bot. We don't want to trigger a rebuild upon pushing this tag
+      # we just want to move the tag, since that's what's used by GHA.
+      - name: Check out code
+        uses: actions/checkout@v3
+        id: checkout
+        with:
+          ref: "v${{ inputs.version }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Move Rolling v1 Tag
+        id: create-rolling-tag
+        run: |
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
+          git tag --force v1
+          git push --tags --force


### PR DESCRIPTION
This job reverts the semgrep-action GHA that our customers use. It does so by rolling the `v1` tag back to a previously know good state. 

This change uses `${{ secrets.GITHUB_TOKEN }}` because we specifically do not want to trigger a rebuild when the tag gets pushed.

### Security
- [x] Changelog has been updated
- [x] Change has no security implications (otherwise, ping the security team)
