### PR TITLE
chore: ensure creds aren't persisted by checkout step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v3
       - uses: pre-commit/action@v2.0.3
 
@@ -19,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - uses: returntocorp/semgrep-action@v1
         with:
           publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - name: Docker meta
         id: docker_meta
         uses: docker/metadata-action@v3.6.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,11 @@ jobs:
               echo "no snapshot changes found"
               exit 0
           fi
+      - name: Configure git creds for push
+        run: |
+          echo "machine github.com" >> ~/.netrc
+          echo "login ${{ github.repository }}" >> ~/.netrc
+          echo "password ${{ secrets.GITHUB_TOKEN }}" >> ~/.netrc
       - name: Commit snapshot updates
         id: snapshot-commit
         if: failure() && github.event_name == 'pull_request' && (github.actor != 'dependabot[bot]' && !(github.event.pull_request.head.repo.full_name != github.repository))
@@ -74,6 +79,8 @@ jobs:
           default_author: github_actions
           message: "Update pytest snapshots"
           new_branch: snapshot-updates-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Remove Credentials
+        run: rm ~/.netrc
       - name: Comment about any snapshot updates
         if: failure() && steps.snapshot-commit.outputs.pushed == 'true'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,8 @@ jobs:
       PIPX_BIN_DIR: .pipx_bin
     steps:
       - uses: actions/checkout@v3
-
+        with:
+          persist-credentials: false
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:
@@ -92,6 +93,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
       - id: semgrep-app-config
         name: with semgrep-app connection
         uses: ./tests/local-image-action

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,8 @@ jobs:
               exit 0
           fi
       - name: Configure git creds for push
+        id: configure-creds
+        if: failure() && github.event_name == 'pull_request' && (github.actor != 'dependabot[bot]' && !(github.event.pull_request.head.repo.full_name != github.repository))
         run: |
           echo "machine github.com" >> ~/.netrc
           echo "login ${{ github.repository }}" >> ~/.netrc
@@ -80,6 +82,8 @@ jobs:
           message: "Update pytest snapshots"
           new_branch: snapshot-updates-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Remove Credentials
+        id: remove-creds
+        if: failure() && github.event_name == 'pull_request' && (github.actor != 'dependabot[bot]' && !(github.event.pull_request.head.repo.full_name != github.repository))
         run: rm ~/.netrc
       - name: Comment about any snapshot updates
         if: failure() && steps.snapshot-commit.outputs.pushed == 'true'

--- a/tests/acceptance/ignore-logs/new-agent.err
+++ b/tests/acceptance/ignore-logs/new-agent.err
@@ -19,5 +19,5 @@ Some files were skipped or only partially analyzed.
 (need more rules? `semgrep login` for additional free Semgrep Registry rules)
 
 CI scan completed successfully.
-  Found 0 findings (0 blocking) from 76 rules.
+  Found 0 findings (0 blocking) from 80 rules.
   No blocking findings so exiting with code 0

--- a/tests/acceptance/multiconfig-generic/new-agent.err
+++ b/tests/acceptance/multiconfig-generic/new-agent.err
@@ -19,5 +19,5 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files changed since baseline commit.
 
 CI scan completed successfully.
-  Found 1 finding (1 blocking) from 76 rules.
+  Found 1 finding (1 blocking) from 80 rules.
   Has findings for blocking rules so exiting with code 1

--- a/tests/acceptance/mutlimerge-generic/new-agent.err
+++ b/tests/acceptance/mutlimerge-generic/new-agent.err
@@ -21,5 +21,5 @@ Some files were skipped or only partially analyzed.
 (need more rules? `semgrep login` for additional free Semgrep Registry rules)
 
 CI scan completed successfully.
-  Found 0 findings (0 blocking) from 76 rules.
+  Found 0 findings (0 blocking) from 80 rules.
   No blocking findings so exiting with code 0

--- a/tests/acceptance/symlink-dir/new-agent.err
+++ b/tests/acceptance/symlink-dir/new-agent.err
@@ -15,5 +15,5 @@ Some files were skipped or only partially analyzed.
   Scan was limited to files changed since baseline commit.
 
 CI scan completed successfully.
-  Found 0 findings (0 blocking) from 76 rules.
+  Found 0 findings (0 blocking) from 80 rules.
   No blocking findings so exiting with code 0


### PR DESCRIPTION
This is a security measure to ensure that credentials are not persisted after the checkout step is complete.

### Security 
- [x] Changelog has been updated
- [x] Change has no security implications (otherwise, ping the security team)
